### PR TITLE
Fix signin page design

### DIFF
--- a/src/components/layout/FormPassword.js
+++ b/src/components/layout/FormPassword.js
@@ -29,7 +29,7 @@ class FormPassword extends Component {
     }
 
     return (
-      <div className="field has-addons">
+      <div className="field has-addons password">
         <div className="control is-expanded">
           {input}
         </div>

--- a/src/components/pages/SigninPage.js
+++ b/src/components/pages/SigninPage.js
@@ -34,9 +34,9 @@ const SigninPage = ({ errors }) => {
                   autoComplete="email"
                   collectionName="users"
                   inputClassName='input is-rounded'
-                  label={<Label title="Adresse e-mail:" />}
+                  label={<Label title="Adresse e-mail" />}
                   name="identifier"
-                  type="email"
+                  // type="email"
                   placeholder="Identifiant (email)"
                 />
                 <FormField

--- a/src/styles/vendors/bulma-with-overrides.scss
+++ b/src/styles/vendors/bulma-with-overrides.scss
@@ -32,9 +32,9 @@
     }
   }
 
-  img {
-    height: 1em;
-  }
+  // img {
+  //   height: 1em;
+  // }
 }
 
 [disabled] {
@@ -70,7 +70,6 @@ input[type="checkbox"], input[type="radio"] {
   }
 }
 
-
 .field {
   &.has-addons {
     .control {
@@ -86,4 +85,9 @@ input[type="checkbox"], input[type="radio"] {
       }
     }
   }
+}
+
+.password:focus-within .button {
+  // For signin form
+  border-color: $input-focus-border-color;
 }


### PR DESCRIPTION
Il reste encore le fait que sur chrome, le background-color des inputs sont jaunes quand on est focus.
Du coup, l'icône oeil ne l'est pas. 
Et sur firefox, cela reste en fond blanc.