### PR TITLE
Fix offerer item informations display

### DIFF
--- a/src/components/OffererItem.js
+++ b/src/components/OffererItem.js
@@ -28,54 +28,52 @@ const OffererItem = ({
           </NavLink>
         </p>
         <ul className='actions'>
-          <li>
-            { get(managedVenues, 'length')
-          ? (
-            <li>
-              <NavLink to={`/structures/${get(offerer, 'id')}/offres/nouveau`}
-                className='has-text-primary'>
-                <Icon svg='ico-offres-r' /> Créer une offre
-              </NavLink>
-            </li>
+          {isActive ? (
+            <li className='is-italic'>En cours de validation : vous allez recevoir un e-mail.</li>
           ) : (
-            <p>Vous n'avez pas encore ajouté de lieu</p>
-          )}
-        </li>
-          <li>
-            {
-              get(managedOccasions, 'length')
-                ? (
-                  <NavLink to={`/offres?offererId=${id}`} className='has-text-primary'>
-                    <Icon svg='ico-offres-r' />
-                    {managedOccasions.length} offre
-                  </NavLink>
-                )
-                : (
-                  // get(managedVenues, 'length') > 0
-                  <p>
-                    0 offre
-                  </p>
-                )
-            }
-          </li>
-          <li>
-            {
-              get(managedVenues, 'length')
-                ? (
-                  <NavLink to={showPath}>
-                    <Icon svg='picto-structure' />
-                    {managedVenues.length} lieu(x)
-                  </NavLink>
-                )
-                : (
-                  <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
-                    className='has-text-primary'>
-                    <Icon svg='picto-structure' /> Ajouter un lieu
-                  </NavLink>
-                )
-            }
-          </li>
-          <li className='is-italic'>{isActive ? 'Activée' : 'En attente de validation'}</li>
+            [
+              <li>
+                <NavLink to={`/offres/nouveau`} className='has-text-primary'>
+                  <Icon svg='ico-offres-r' />
+                  Nouvelle offre
+                </NavLink>
+              </li>,
+              <li>
+                {
+                  get(managedOccasions, 'length')
+                    ? (
+                      <NavLink to={`/offres?offererId=${id}`} className='has-text-primary'>
+                        <Icon svg='ico-offres-r' />
+                        {managedOccasions.length} offre
+                      </NavLink>
+                    )
+                    : (
+                      <p>
+                        0 offre
+                      </p>
+                    )
+                }
+              </li>,
+              <li>
+                {
+                  get(managedVenues, 'length')
+                    ? (
+                      <NavLink to={showPath}>
+                        <Icon svg='picto-structure' />
+                        {managedVenues.length} lieu
+                      </NavLink>
+                      )
+                    : (
+                      <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
+                        className='has-text-primary'>
+                        <Icon svg='picto-structure' /> Ajouter un lieu
+                      </NavLink>
+                      )
+                  }
+              </li>,
+            ]
+          )
+          }
         </ul>
       </div>
       <div className='caret'>

--- a/src/components/OffererItem.js
+++ b/src/components/OffererItem.js
@@ -32,57 +32,50 @@ const OffererItem = ({
             <li className='is-italic'>En cours de validation : vous allez recevoir un e-mail.</li>
           ) : (
             [
-              <li>
-                {
-                  get(managedVenues, 'length')
-                  ? (
-                    <NavLink to={`/offres/nouveau`} className='has-text-primary'>
+              // J'ai déja ajouté Un lieu mais pas d'offres
+              get(managedVenues, 'length') > 0  ?
+              (
+              [
+                <li>
+                  <NavLink to={`/offres/nouveau`} className='has-text-primary'>
                     <Icon svg='ico-offres-r' />
                     Nouvelle offre
                   </NavLink>
-                ) :
-                ''
-                }
-              </li>,
+                </li>,
+                // J'ai au moins 1 offre
+                get(managedOccasions, 'length') > 0 &&
+                  <li>
+                    <NavLink to={`/offres?offererId=${id}`} className='has-text-primary'>
+                      <Icon svg='ico-offres-r' />
+                      { managedOccasions.length === 1 ?  (`${managedOccasions.length} offre`) :
+                      (`${managedOccasions.length} offres`)}
+                    </NavLink>
+                  </li>,
+                get(managedOccasions, 'length') === 0 &&
+                <li>0 offre</li>
+              ]
+              ) : (
+                <li className='is-italic'>Créez un lieu pour pouvoir y associer des offres.</li>
+              ),
+              // J'ai ajouté un lieu
+              get(managedVenues, 'length')  > 0 ?
+              (
+                <li>
+                  <NavLink to={showPath}>
+                    <Icon svg='ico-offres-r' />
+                    { managedVenues.length === 1 ?  (`${managedVenues.length} lieu`) :
+                    (`${managedVenues.length} lieux`)}
+                  </NavLink>
+                </li>
+              ) :
+              // je n'ai pas encore ajouté de lieu
               <li>
-                {
-                  get(managedOccasions, 'length')
-                    ? (
-                      <NavLink to={`/offres?offererId=${id}`} className='has-text-primary'>
-                        <Icon svg='ico-offres-r' />
-                        {managedOccasions.length} offre
-                      </NavLink>
-                    )
-                    : ( get(managedVenues, 'length') ? (
-                      <p>
-                        0 offre
-                      </p>
-                    ) : ''
-                    )
-                }
-              </li>,
-              <li>
-                {
-                  get(managedVenues, 'length')
-                    ? (
-                      <NavLink to={showPath}>
-                        <Icon svg='picto-structure' />
-                        {managedVenues.length} lieu
-                      </NavLink>
-                      )
-                    : (
-                      [
-                        <p>Vous devez avoir déjà enregistré un lieu pour ajouter des offres</p>,
-                        <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
-                        className='has-text-primary'>
-                        <Icon svg='picto-structure' /> Ajouter un lieu
-                      </NavLink>
-                      ]
-                      )
-                  }
-              </li>,
-            ]
-          )
+                <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
+                className='has-text-primary'>
+                <Icon svg='picto-structure' /> Ajouter un lieu
+              </NavLink>
+              </li>
+          ])
           }
         </ul>
       </div>

--- a/src/components/OffererItem.js
+++ b/src/components/OffererItem.js
@@ -28,26 +28,30 @@ const OffererItem = ({
           </NavLink>
         </p>
         <ul className='actions'>
-          {
-            get(managedVenues, 'length') && (
-              <li>
-                <NavLink to={`/structures/${get(offerer, 'id')}/offres/nouveau`}
-                  className='has-text-primary'>
-                  <Icon svg='ico-offres-r' /> Créer une offre
-                </NavLink>
-              </li>
-            )
-          }
+          <li>
+            { get(managedVenues, 'length')
+          ? (
+            <li>
+              <NavLink to={`/structures/${get(offerer, 'id')}/offres/nouveau`}
+                className='has-text-primary'>
+                <Icon svg='ico-offres-r' /> Créer une offre
+              </NavLink>
+            </li>
+          ) : (
+            <p>Vous n'avez pas encore ajouté de lieu</p>
+          )}
+        </li>
           <li>
             {
               get(managedOccasions, 'length')
                 ? (
                   <NavLink to={`/offres?offererId=${id}`} className='has-text-primary'>
                     <Icon svg='ico-offres-r' />
-                    {managedOccasions.length} offres
+                    {managedOccasions.length} offre
                   </NavLink>
                 )
                 : (
+                  // get(managedVenues, 'length') > 0
                   <p>
                     0 offre
                   </p>
@@ -60,13 +64,14 @@ const OffererItem = ({
                 ? (
                   <NavLink to={showPath}>
                     <Icon svg='picto-structure' />
-                    {managedVenues.length} lieux
+                    {managedVenues.length} lieu(x)
                   </NavLink>
                 )
                 : (
-                  <p>
-                    0 lieu
-                  </p>
+                  <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
+                    className='has-text-primary'>
+                    <Icon svg='picto-structure' /> Ajouter un lieu
+                  </NavLink>
                 )
             }
           </li>

--- a/src/components/OffererItem.js
+++ b/src/components/OffererItem.js
@@ -28,15 +28,21 @@ const OffererItem = ({
           </NavLink>
         </p>
         <ul className='actions'>
-          {isActive ? (
+          {!isActive ? (
             <li className='is-italic'>En cours de validation : vous allez recevoir un e-mail.</li>
           ) : (
             [
               <li>
-                <NavLink to={`/offres/nouveau`} className='has-text-primary'>
-                  <Icon svg='ico-offres-r' />
-                  Nouvelle offre
-                </NavLink>
+                {
+                  get(managedVenues, 'length')
+                  ? (
+                    <NavLink to={`/offres/nouveau`} className='has-text-primary'>
+                    <Icon svg='ico-offres-r' />
+                    Nouvelle offre
+                  </NavLink>
+                ) :
+                ''
+                }
               </li>,
               <li>
                 {
@@ -47,10 +53,11 @@ const OffererItem = ({
                         {managedOccasions.length} offre
                       </NavLink>
                     )
-                    : (
+                    : ( get(managedVenues, 'length') ? (
                       <p>
                         0 offre
                       </p>
+                    ) : ''
                     )
                 }
               </li>,
@@ -64,10 +71,13 @@ const OffererItem = ({
                       </NavLink>
                       )
                     : (
-                      <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
+                      [
+                        <p>Vous devez avoir déjà enregistré un lieu pour ajouter des offres</p>,
+                        <NavLink to={`/structures/${get(offerer, 'id')}/lieux/nouveau`}
                         className='has-text-primary'>
                         <Icon svg='picto-structure' /> Ajouter un lieu
                       </NavLink>
+                      ]
                       )
                   }
               </li>,

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -19,7 +19,6 @@ class Header extends Component {
   render() {
     const {
       name,
-      venuesCount,
       whiteHeader
     } = this.props
     const {
@@ -51,13 +50,11 @@ class Header extends Component {
             <span className='icon'><Icon svg={'ico-guichet-w'} /></span>
             <span>Guichet</span>
           </NavLink>,
-          venuesCount > 0 && (
             <NavLink className="navbar-item" to={'/offres'} key={1}>
             <span className='icon'><Icon svg={'ico-offres-w'} /></span>
             <span>Vos offres</span>
           </NavLink>
-        )
-      ]
+        ]
     }
       <div className="navbar-item has-dropdown is-hoverable">
         <NavLink className="navbar-link" to="#">
@@ -104,7 +101,6 @@ class Header extends Component {
 
 export default connect(
   state => ({
-    venuesCount: get(state, 'data.venues.length'),
     name: get(state, 'user.publicName')
   })
 )(Header)


### PR DESCRIPTION
Cette PR permet 

- d'afficher un message annonçant que la structure n'est pas encore activée
- d'afficher les offres seulement si au moins un lieu est ajouté
- d'afficher un message si aucun lieu n'a été ajouté plus un lien

- affiche les offres dans le menu du header même si le user n'a pas ajouté de lieu ou d'offres

@augnustin 

Linked to https://github.com/betagouv/pass-culture-browser/issues/345