### PR TITLE
`get /users/me` in `componentDidMount`

### DIFF
--- a/src/components/hocs/withLogin.js
+++ b/src/components/hocs/withLogin.js
@@ -20,33 +20,25 @@ const withLogin = (config = {}) => WrappedComponent => {
       this.redirectTo = redirectTo
     }
 
-    componentWillMount = () => {
-      const { user, requestData } = this.props
-      if (this.isRequired && !user) {
-        requestData('GET', `users/me`, { key: 'users' })
-      }
-    }
-
     componentDidMount = () => {
-      this.handleRedirect()
-    }
+      const {
+        history,
+        location,
+        user,
+        requestData
+      } = this.props
 
-    componentDidUpdate = prevProps => {
-      this.handleRedirect(prevProps)
-    }
-
-    handleRedirect = (prevProps={}) => {
-      const { history, location, user } = this.props
-      if (user && user !== prevProps.user) {
-        if (!prevProps.user && this.redirectTo && this.redirectTo !== location.pathname) {
-          history.push(this.redirectTo)
-        }
-      } else if (this.isRequired) {
-        if (user === false && prevProps.user === null) {
-          // CASE WHERE WE STILL HAVE A USER NULL
-          // SO WE FORCE THE SIGNING PUSH
-          history.push('/connexion')
-        }
+      if (user === null && this.isRequired) {
+        requestData('GET', `users/me`, {
+          key: 'users',
+          handleSuccess: () => {
+            if (this.redirectTo && this.redirectTo !== location.pathname)
+              history.push(this.redirectTo)
+          },
+          handleFail: () => {
+            history.push('/connexion')
+          }
+        })
       }
     }
 

--- a/src/components/hocs/withSign.js
+++ b/src/components/hocs/withSign.js
@@ -13,7 +13,6 @@ const withSign = WrappedComponent => {
   class _withSign extends Component {
     constructor (props) {
       super()
-      props.resetErrors()
     }
 
     componentDidUpdate() {
@@ -29,6 +28,7 @@ const withSign = WrappedComponent => {
     }
 
     componentWillUnmount() {
+      this.props.resetErrors()
       this.props.resetForm()
     }
 

--- a/src/sagas/user.js
+++ b/src/sagas/user.js
@@ -7,15 +7,17 @@ import { put,
 import { resetData } from '../reducers/data'
 import { setUser } from '../reducers/user'
 
+function* fromWatchRequestSignActions(action) {
+  yield put(setUser(false)) // false while querying
+}
+
 function* fromWatchFailSignActions(action) {
-  // force to update by changing value null to false or false to null
-  const currentUser = yield select(state => state.user)
-  yield put(setUser(currentUser === false ? null : false))
+  yield put(setUser(null)) // null otherwise
 }
 
 function* fromWatchSuccessGetSignoutActions() {
   yield put(resetData())
-  yield put(setUser(false))
+  yield put(setUser(null))
 }
 
 function* fromWatchSuccessSignActions() {
@@ -33,6 +35,12 @@ function* fromWatchSuccessSignActions() {
 }
 
 export function* watchUserActions() {
+  yield takeEvery(
+    ({ type }) =>
+      /REQUEST_DATA_POST_USERS\/SIGN(.*)/.test(type) ||
+      /REQUEST_DATA_GET_USERS\/ME(.*)/.test(type),
+    fromWatchRequestSignActions
+  )
   yield takeEvery(
     ({ type }) =>
       /FAIL_DATA_POST_USERS\/SIGN(.*)/.test(type) ||


### PR DESCRIPTION
J'avoue c'était ptet pas l'urgence mais ça me tracassait beaucoup : j'aime pas avoir des messages d'erreur dans la console.

Je ne l'ai plus sous la main, mais grosso-modo, lors d'un changement de page, j'avais une erreur qui disait que `setState` avait été appelé sur un composant unmounted et donc qu'on avait des memory leaks.

Mon guess c'était que ça provenait du fait que j'ai ajouté le `withLogin` dans le `PageWrapper` et que `withLogin` lançait une requête dans `componentWillMount`, ce qui n'est pas considéré comme une bonne pratique : https://stackoverflow.com/questions/27139366/why-do-the-react-docs-recommend-doing-ajax-in-componentdidmount-not-componentwi

Je comprends la logique de *il faut lancer la requête le plus tôt possible*, mais a priori ça ne retarde pas beaucoup. 

En revanche ce qui était nécessaire c'est de vérifier que `get /users/me` n'était bien appelé qu'une fois, sinon on n'a pas gagné grand chose. A priori ça fonctionne. Enfin, j'utilise les très élégants `handleSuccess` et `handleFail` plutôt que de faire une comparaison sur `props.user`.

A voir si ça corrige le problème (il était difficilement reproductible de manière déterministe), mais ça me semble clean dans l'ensemble.

J'ai bien vérifié que cela n'entrainait pas de régression, au passage, j'ai fixé un mini-truc qui n'affichait pas `Authentification nécessaire` lors du redirect si on tente une page logguée `withLogin: isRequired` sans l'être.


