### PR TITLE
Shared folder without symlink

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -90,7 +90,7 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
 
-      //shared: path.resolve(__dirname, '../shared')
+      shared: path.resolve(__dirname, '../../shared/src'),
     },
     plugins: [
       // Prevents users from importing files from outside of src/ (or node_modules/).
@@ -98,7 +98,7 @@ module.exports = {
       // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
       // please link the files into your node_modules/ and let module-resolution kick in.
       // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
+      // new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
     ],
   },
   module: {

--- a/src/components/hocs/withCurrentOccasion.js
+++ b/src/components/hocs/withCurrentOccasion.js
@@ -1,4 +1,5 @@
-import { requestData } from 'pass-culture-shared'
+import { requestData } from 'shared/reducers/data'
+// import { requestData } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'


### PR DESCRIPTION
`import { requestData } from 'shared/reducers/data'` au lieu de `import { requestData } from 'pass-culture-shared'` que je trouve beaucoup plus confusant.