### PR TITLE
added withLogin in every pages

### DIFF
--- a/src/components/layout/Main.js
+++ b/src/components/layout/Main.js
@@ -9,7 +9,6 @@ import {
   showNotification,
   Spinner,
   withBlock,
-  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -164,9 +163,6 @@ class Main extends Component {
 
 export default compose(
   withRouter,
-  withLogin({
-    failRedirect: '/connexion',
-  }),
   withBlock,
   connect(
     state => ({

--- a/src/components/pages/AccountingPage.js
+++ b/src/components/pages/AccountingPage.js
@@ -1,3 +1,4 @@
+import { withLogin } from 'pass-culture-shared'
 import React, { Component } from 'react'
 
 import Main from '../layout/Main'
@@ -8,4 +9,4 @@ class AccoutingPage extends Component {
   }
 }
 
-export default AccoutingPage
+export default withLogin({ failRedirect: '/connexion' })(AccoutingPage)

--- a/src/components/pages/CounterPage.js
+++ b/src/components/pages/CounterPage.js
@@ -1,4 +1,4 @@
-import { Icon } from 'pass-culture-shared'
+import { Icon, withLogin } from 'pass-culture-shared'
 import React from 'react'
 import { Link } from 'react-router-dom'
 
@@ -49,4 +49,4 @@ const CounterPage = () => {
   )
 }
 
-export default CounterPage
+export default withLogin({ failRedirect: '/connexion' })(CounterPage)

--- a/src/components/pages/HomePage.js
+++ b/src/components/pages/HomePage.js
@@ -1,4 +1,4 @@
-import { Icon } from 'pass-culture-shared'
+import { Icon, withLogin } from 'pass-culture-shared'
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 
@@ -37,4 +37,4 @@ const HomePage = ({ user }) => {
   )
 }
 
-export default HomePage
+export default withLogin({ failRedirect: '/connexion' })(HomePage)

--- a/src/components/pages/MediationPage.js
+++ b/src/components/pages/MediationPage.js
@@ -1,6 +1,6 @@
 import classnames from 'classnames'
 import get from 'lodash.get'
-import { requestData, showNotification } from 'pass-culture-shared'
+import { requestData, showNotification, withLogin } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import ReactMarkdown from 'react-markdown'
 import { connect } from 'react-redux'
@@ -301,6 +301,7 @@ class MediationPage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   withRouter,
   connect(
     (state, ownProps) => {

--- a/src/components/pages/MediationsPage.js
+++ b/src/components/pages/MediationsPage.js
@@ -1,3 +1,4 @@
+import { withLogin } from 'pass-culture-shared'
 import React from 'react'
 
 import Main from '../layout/Main'
@@ -11,4 +12,4 @@ const MediationsPage = () => {
   )
 }
 
-export default MediationsPage
+export default withLogin({ failRedirect: '/connexion' })(MediationsPage)

--- a/src/components/pages/OfferPage.js
+++ b/src/components/pages/OfferPage.js
@@ -9,6 +9,7 @@ import {
   showModal,
   showNotification,
   SubmitButton,
+  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -384,6 +385,7 @@ class OfferPage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   withRouter,
   connect(
     (state, ownProps) => {

--- a/src/components/pages/OffererPage.js
+++ b/src/components/pages/OffererPage.js
@@ -7,6 +7,7 @@ import {
   requestData,
   showNotification,
   SubmitButton,
+  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -149,6 +150,7 @@ class OffererPage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   withRouter,
   connect(
     (state, ownProps) => {

--- a/src/components/pages/OfferersPage.js
+++ b/src/components/pages/OfferersPage.js
@@ -1,4 +1,4 @@
-import { requestData } from 'pass-culture-shared'
+import { requestData, withLogin } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
@@ -49,6 +49,7 @@ class OfferersPage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   connect(
     (state, ownProps) => ({
       offerers: offerersSelector(state),

--- a/src/components/pages/OffersPage.js
+++ b/src/components/pages/OffersPage.js
@@ -6,6 +6,7 @@ import {
   resolveIsNew,
   showModal,
   withSearch,
+  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -158,6 +159,7 @@ class OffersPage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   withRouter,
   withSearch({
     dataKey: 'offers',

--- a/src/components/pages/ProfilePage.js
+++ b/src/components/pages/ProfilePage.js
@@ -3,9 +3,11 @@ import {
   Form,
   showNotification,
   SubmitButton,
+  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { compose } from 'redux'
 
 import Main from '../layout/Main'
 import UploadThumb from '../layout/UploadThumb'
@@ -73,11 +75,14 @@ class ProfilePage extends Component {
   }
 }
 
-export default connect(
-  state => ({
-    user: state.user,
-  }),
-  {
-    showNotification,
-  }
+export default compose(
+  withLogin({ failRedirect: '/connexion' }),
+  connect(
+    state => ({
+      user: state.user,
+    }),
+    {
+      showNotification,
+    }
+  )
 )(ProfilePage)

--- a/src/components/pages/VenuePage.js
+++ b/src/components/pages/VenuePage.js
@@ -8,6 +8,7 @@ import {
   requestData,
   showNotification,
   SubmitButton,
+  withLogin,
 } from 'pass-culture-shared'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
@@ -256,6 +257,7 @@ class VenuePage extends Component {
 }
 
 export default compose(
+  withLogin({ failRedirect: '/connexion' }),
   withRouter,
   connect(
     (state, ownProps) => {


### PR DESCRIPTION
... je merge ca rapidement pour refaire marcher le master qui utilise pass-culture-shared 0.0.20 qui utilise le nouveau login plus simple... Mais pour le moment, c'est plus logique et simple de faire ce hoc withLogin un peu configuré specifiquement pour chaque page plutôt ue de l'imaginer centralement quelque part. (car notamment la SigninPage et la SignuPage ne doivent pas l'avoir)

Une fois qu'on a poussé le mvp of course je suis ouvert à trouver mieux.