### PR TITLE
#626 Fix bad venueId populated

### DIFF
--- a/src/components/pages/OfferPage.js
+++ b/src/components/pages/OfferPage.js
@@ -400,7 +400,7 @@ class OfferPage extends Component {
                       <div className="field-body">
                         <p className="help is-danger">
                           Il faut obligatoirement une structure avec un lieu.
-                          <Field type="hidden" name="venueId" required />
+                          <Field type="hidden" name="__BLOCK_FORM__" required />
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
Il y a quelque chose d'un peu trop *magique* avec le form, à voir avec @Ledoux peut-être.

En attendant ce fix fait aussi bien le travail, le principe étant d'avoir un champ requis non renseigné pour empêcher la soumission du formulaire.

Issue : https://github.com/betagouv/pass-culture-browser/issues/626