### PR TITLE
inverted order of long lat fields in venue form

### DIFF
--- a/src/components/pages/VenuePage.js
+++ b/src/components/pages/VenuePage.js
@@ -191,8 +191,8 @@ class VenuePage extends Component {
                   name="city"
                   required
                 />
-                <Field label="Longitude" name="longitude" required />
                 <Field label="Latitude" name="latitude" required />
+                <Field label="Longitude" name="longitude" required />
               </div>
             </div>
             <hr />


### PR DESCRIPTION
parce que y a emmaus typiquemnt qui s'est planté en remplissant les coordonnées à la main de sonlieu.

Et c'est vrai que c'est mieux de faire l'ordre Lat puis Long car google maps le donne dans cet ordre.