### PR TITLE
Add git commit hash in termsPage

### DIFF
--- a/src/components/pages/TermsPage.js
+++ b/src/components/pages/TermsPage.js
@@ -1,7 +1,11 @@
 import React, { Component } from 'react'
 import ReactMarkdown from 'react-markdown'
 
+import PropTypes from 'prop-types'
+
 import Main from '../layout/Main'
+
+import { LAST_DEPLOYED_COMMIT } from '../../utils/config'
 
 // TODO: import this from other file
 const mardownContent = `
@@ -50,6 +54,7 @@ feugiat orci ut diam ullamcorper consequat.
 
 class TermsPage extends Component {
   render() {
+    const { lastDeployedCommit } = this.props
     return (
       <Main name="terms" noHeader backButton>
         <header>
@@ -57,10 +62,22 @@ class TermsPage extends Component {
         </header>
         <div className="content">
           <ReactMarkdown source={mardownContent} />
+          <div className="mt16">
+            <p className="text-right">{`Pass Culture - ${lastDeployedCommit}`}</p>
+          </div>
         </div>
       </Main>
     )
   }
+}
+
+TermsPage.defaultProps = {
+  lastDeployedCommit: LAST_DEPLOYED_COMMIT,
+}
+TermsPage.propTypes = {
+  // NOTE -> `lastDeployedCommit`
+  // `lastDeployedCommit` est rempli au build par le script PC
+  lastDeployedCommit: PropTypes.string,
 }
 
 export default TermsPage

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -5,6 +5,10 @@ import 'moment-timezone'
 moment.locale('fr-fr')
 
 const NODE_ENV = process.env.NODE_ENV || 'development'
+// NOTE -> le script PC remplace
+// la valeur de `LAST_DEPLOYED_COMMIT`
+// par le numéro de commit qui a été deployé
+export const LAST_DEPLOYED_COMMIT = '##LAST_DEPLOYED_COMMIT##'
 
 export const IS_DEBUG = true
 


### PR DESCRIPTION
Cela me permettrait de logger la dernière version déployée en prod avec son hash. Ensuite je pourrais la récupérer pour lancer les tests testscafe sur API ticket 916