### PR TITLE
[PC 1423] used pcs 101 that unmount modal by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "node-env-file": "^0.1.8",
     "node-sass": "^4.9.0",
     "object-assign": "4.1.1",
-    "pass-culture-shared": "0.0.100",
+    "pass-culture-shared": "0.0.101",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",
     "promise": "8.0.1",

--- a/src/components/pages/Offer/EventOccurrencesAndStocksManager.jsx
+++ b/src/components/pages/Offer/EventOccurrencesAndStocksManager.jsx
@@ -39,10 +39,22 @@ class EventOccurrencesAndStocksManager extends Component {
     this.state = { info: null }
   }
 
-  onCloseClick = e => {
-    const { dispatch, offer, history } = this.props
-    dispatch(closeModal())
-    history.push(`/offres/${get(offer, 'id')}`)
+  componentDidMount() {
+    this.elem.focus()
+    document.addEventListener('keydown', this.onKeydown)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onKeydown)
+  }
+
+  handleEscKey() {
+    if (!this.props.isEditing) {
+      this.onCloseClick()
+    } else {
+      const cancelButton = document.getElementsByClassName('cancel-step')[0]
+      cancelButton.click()
+    }
   }
 
   handleEnterKey() {
@@ -64,15 +76,6 @@ class EventOccurrencesAndStocksManager extends Component {
     }
   }
 
-  handleEscKey() {
-    if (!this.props.isEditing) {
-      this.onCloseClick()
-    } else {
-      const cancelButton = document.getElementsByClassName('cancel-step')[0]
-      cancelButton.click()
-    }
-  }
-
   getAddUrl(isEditing, isStockOnly) {
     return getAddUrl(
       isEditing,
@@ -91,19 +94,18 @@ class EventOccurrencesAndStocksManager extends Component {
     this.setState({ info })
   }
 
-  componentDidMount() {
-    this.elem.focus()
-    document.onkeydown = event => {
-      if (event.key === 'Enter') {
-        this.handleEnterKey()
-      } else if (event.key === 'Escape') {
-        this.handleEscKey()
-      }
-    }
+  onCloseClick = e => {
+    const { dispatch, offer, history } = this.props
+    dispatch(closeModal())
+    history.push(`/offres/${get(offer, 'id')}`)
   }
 
-  componentWillUnmount() {
-    document.onkeydown = null
+  onKeydown = event => {
+    if (event.key === 'Enter') {
+      this.handleEnterKey()
+    } else if (event.key === 'Escape') {
+      this.handleEscKey()
+    }
   }
 
   render() {

--- a/src/components/pages/Offer/EventOccurrencesAndStocksManager.jsx
+++ b/src/components/pages/Offer/EventOccurrencesAndStocksManager.jsx
@@ -259,6 +259,7 @@ class EventOccurrencesAndStocksManager extends Component {
         </div>
         <button
           className="button is-secondary is-pulled-right"
+          id="close-manager"
           onClick={this.onCloseClick}>
           Fermer
         </button>

--- a/src/components/pages/Offer/index.jsx
+++ b/src/components/pages/Offer/index.jsx
@@ -662,8 +662,8 @@ class OfferPage extends Component {
               <div className="control">
                 {isReadOnly ? (
                   <NavLink
-                    to={`/offres/${offerId}?modifie`}
-                    className="button is-secondary is-medium">
+                    className="button is-secondary is-medium"
+                    to={`/offres/${offerId}?modifie`}>
                     Modifier l'offre
                   </NavLink>
                 ) : (

--- a/src/components/pages/Signup/SignupForm.jsx
+++ b/src/components/pages/Signup/SignupForm.jsx
@@ -18,7 +18,8 @@ class SignupForm extends PureComponent {
               className="is-secondary"
               href="https://pass.culture.fr/assets/docs/Pas_a_pas_pass_Culture.pdf"
               target="_blank"
-              rel="noreferrer noopener">
+              rel="noopener noreferrer"
+            >
               modalités de fonctionnement en cliquant ici
             </a>{' '}
             avant de renseigner les champs suivants.

--- a/testcafe/08_stocks.js
+++ b/testcafe/08_stocks.js
@@ -11,7 +11,9 @@ import {
 import { EXISTING_VALIDATED_UNREGISTERED_93_OFFERER_USER } from './helpers/users'
 
 const addAnchor = Selector('#add-occurrence-or-stock')
+const backButton = Selector('a.back-button')
 const availableInput = Selector('input[name="available"]')
+const closeManagerButton = Selector('#close-manager')
 const manageStockAnchor = Selector('a.manage-stock')
 const submitButton = Selector('button.button.submitStep')
 const priceInput = Selector('input[name="price"]')
@@ -294,6 +296,27 @@ test('Je peux modifier une occurrence et un stock', async t => {
   // then
   location = await t.eval(() => window.location)
   await t.expect(location.search).match(/\?gestion$/)
+})
+
+test('Je peux aller sur le stock manager et revenir aux offres pour chercher une nouvelle offre sans bug de modal en appuyant sur enter', async t => {
+  // given
+  await navigateToOfferAs(
+    EXISTING_VALIDATED_UNREGISTERED_93_OFFERER_USER,
+    EXISTING_EVENT_OFFER_WITH_EVENT_OCCURRENCE_WITH_STOCK_WITH_MEDIATION_WITH_93_OFFERER_IBAN_WITH_NO_VENUE_IBAN
+  )(t)
+  const searchInput = Selector('#search')
+  await t
+    .click(manageStockAnchor)
+    .click(closeManagerButton)
+    .click(backButton)
+    .typeText(searchInput, 'blabla')
+
+  // when
+  await t.pressKey('Enter')
+
+  // then
+  const location = await t.eval(() => window.location)
+  await t.expect(location.pathname).eql('/offres')
 })
 
 fixture.skip`TODO: OfferPage Gestion D | Effacer des dates et des stocks`

--- a/yarn.lock
+++ b/yarn.lock
@@ -7039,9 +7039,9 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
 
-pass-culture-shared@0.0.100:
-  version "0.0.100"
-  resolved "https://registry.yarnpkg.com/pass-culture-shared/-/pass-culture-shared-0.0.100.tgz#89973f4cd5c00f87b40b11e1a714c1f599e6e25d"
+pass-culture-shared@0.0.101:
+  version "0.0.101"
+  resolved "https://registry.yarnpkg.com/pass-culture-shared/-/pass-culture-shared-0.0.101.tgz#4e819a9b75a1e927f328aaedab9361d53289d429"
   dependencies:
     classnames "2.2.5"
     eslint "^5.8.0"


### PR DESCRIPTION
Explication du problème: le component Modal garde toujours mounté son enfant $modal,même quand on changeait de page. Ainsi si le $modal était avec des eventListeners d'instancés au did mount (specifique à la page où la modal est appelé), ils etaient aussi instancés en side effect sur les autres pages.

Le fix est fait sur shared ici:  https://github.com/betagouv/pass-culture-shared/pull/88

Et de faire ici:
```
yarn install
```