### PR TITLE
(PC-2130) add test-cafe screenshot to artefact in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,8 @@ jobs:
             cd ~/pass-culture-main/pro
             dockerize -wait http://localhost/health -timeout 5m -wait-retry-interval 5s
             yarn test:cafe
+      - store_artifacts:
+         path: ~/pass-culture-main/pro/testcafe_screenshots
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "licenses": "node_modules/.bin/license-reporter save --json licenses.json",
     "precommit": "pretty-quick --staged --pattern '**/*.*(js|jsx)'",
     "prettier": "$(yarn bin)/prettier --write 'src/**/*.js'",
-    "test:cafe": "testcafe --assertion-timeout 5000 --selector-timeout 15000 'chrome:headless' testcafe",
+    "test:cafe": "testcafe --assertion-timeout 5000 --selector-timeout 15000 -S -s testcafe_screenshots 'chrome:headless' testcafe",
     "test:unit": "jest --env=jsdom",
     "symlink-shared": "if [ -d \"../shared\" ]; then cd node_modules && rm -rf pass-culture-shared && ln -sf ../../shared pass-culture-shared && cd ../../shared && yarn run compile; fi",
     "start": "node scripts/start.js"


### PR DESCRIPTION
Le but est est de retrouver les screentshots quand il y des erreurs test-café. Ils seront dans circleci dans l'onglet "Artefact" du menu "Test summary"