### PR TITLE
[QUICK WIN] Remove toBeDefined when its unnecessary within a test

### DIFF
--- a/src/components/hocs/with-login/__specs__/__snapshots__/withNotRequiredLogin.spec.jsx.snap
+++ b/src/components/hocs/with-login/__specs__/__snapshots__/withNotRequiredLogin.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | hocs | with-login | withNotRequiredLogin snapshot should match snapshot 1`] = `
+exports[`src | components | pages | hocs | with-login | withNotRequiredLogin should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.jsx.snap
+++ b/src/components/hocs/with-login/__specs__/__snapshots__/withRequiredLogin.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | hocs | with-login | withRequiredLogin snapshot should match snapshot 1`] = `
+exports[`src | components | pages | hocs | with-login | withRequiredLogin should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <withRouter(_withQueryRouter) />,

--- a/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.jsx
+++ b/src/components/hocs/with-login/__specs__/withNotRequiredLogin.spec.jsx
@@ -20,15 +20,12 @@ describe('src | components | pages | hocs | with-login | withNotRequiredLogin', 
     fetch.resetMocks()
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<NotRequiredLogin />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<NotRequiredLogin />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('functions', () => {

--- a/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.jsx
+++ b/src/components/hocs/with-login/__specs__/withRequiredLogin.spec.jsx
@@ -19,15 +19,12 @@ describe('src | components | pages | hocs | with-login | withRequiredLogin', () 
     fetch.resetMocks()
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<RequiredLoginTest />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<RequiredLoginTest />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('functions', () => {

--- a/src/components/layout/DownloadButton/__specs__/DownloadButton.spec.jsx
+++ b/src/components/layout/DownloadButton/__specs__/DownloadButton.spec.jsx
@@ -4,22 +4,20 @@ import { shallow } from 'enzyme'
 import DownloadButton from '../DownloadButton'
 
 describe('src | components | Layout | DownloadButton', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        children: 'Fake title',
-        downloadFileOrNotifyAnError: () => jest.fn(),
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      children: 'Fake title',
+      downloadFileOrNotifyAnError: () => jest.fn(),
+    }
 
-      // when
-      const wrapper = shallow(<DownloadButton {...props} />)
+    // when
+    const wrapper = shallow(<DownloadButton {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
+
   describe('render', () => {
     it('should set loading and disabled during onClick', () => {
       return new Promise(done => {

--- a/src/components/layout/DownloadButton/__specs__/__snapshots__/DownloadButton.spec.jsx.snap
+++ b/src/components/layout/DownloadButton/__specs__/__snapshots__/DownloadButton.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | Layout | DownloadButton snapshot should match snapshot 1`] = `
+exports[`src | components | Layout | DownloadButton should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <DownloadButton

--- a/src/components/layout/Header/__specs__/Header.spec.jsx
+++ b/src/components/layout/Header/__specs__/Header.spec.jsx
@@ -89,7 +89,6 @@ describe('src | components | Layout | Header', () => {
           .find('.navbar-end')
           .find('.navbar-item')
           .at(2)
-        expect(helpLink).toBeDefined()
         expect(helpLink.prop('href')).toBe('https://docs.passculture.app/structures-culturelles')
         expect(helpLink.prop('target')).toBe('_blank')
       })

--- a/src/components/layout/HeroSection/__specs__/HeroSection.spec.jsx
+++ b/src/components/layout/HeroSection/__specs__/HeroSection.spec.jsx
@@ -4,21 +4,18 @@ import { shallow } from 'enzyme'
 import HeroSection from '../HeroSection'
 
 describe('src | components | layout | HeroSection', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        subtitle: 'Fake subtitle',
-        title: 'Fake title',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      subtitle: 'Fake subtitle',
+      title: 'Fake title',
+    }
 
-      // when
-      const wrapper = shallow(<HeroSection {...props}> </HeroSection>)
+    // when
+    const wrapper = shallow(<HeroSection {...props}> </HeroSection>)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/layout/HeroSection/__specs__/__snapshots__/HeroSection.spec.jsx.snap
+++ b/src/components/layout/HeroSection/__specs__/__snapshots__/HeroSection.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | HeroSection snapshot should match snapshot 1`] = `
+exports[`src | components | layout | HeroSection should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <HeroSection

--- a/src/components/layout/Main/tests/Main.spec.js
+++ b/src/components/layout/Main/tests/Main.spec.js
@@ -19,7 +19,6 @@ describe('src | components | layout | Main', () => {
     const wrapper = shallow(<Main {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/layout/Notification/__specs__/Notification.spec.js
+++ b/src/components/layout/Notification/__specs__/Notification.spec.js
@@ -16,15 +16,12 @@ describe('src | components | layout | Notification', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Notification {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Notification {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/layout/Notification/__specs__/__snapshots__/Notification.spec.js.snap
+++ b/src/components/layout/Notification/__specs__/__snapshots__/Notification.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | Notification snapshot should match snapshot 1`] = `
+exports[`src | components | layout | Notification should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Notification

--- a/src/components/layout/__specs__/UploadThumb.spec.js
+++ b/src/components/layout/__specs__/UploadThumb.spec.js
@@ -18,7 +18,6 @@ describe('src | components | pages | Offer | UploadThumb | computeZoom', () => {
     const newZoom = computeNewZoom(current, min, max, step, factor, direction)
 
     // then
-    expect(newZoom).toBeDefined()
     expect(newZoom).toBeGreaterThan(current)
   })
 
@@ -31,7 +30,6 @@ describe('src | components | pages | Offer | UploadThumb | computeZoom', () => {
     const newZoom = computeNewZoom(current, min, max, step, factor, direction)
 
     // then
-    expect(newZoom).toBeDefined()
     expect(newZoom).toBeLessThan(current)
   })
 
@@ -45,7 +43,6 @@ describe('src | components | pages | Offer | UploadThumb | computeZoom', () => {
     const newZoom = computeNewZoom(current, min, max, step, factor, direction)
 
     // then
-    expect(newZoom).toBeDefined()
     expect(newZoom).toStrictEqual(current)
   })
 
@@ -58,7 +55,6 @@ describe('src | components | pages | Offer | UploadThumb | computeZoom', () => {
     const newZoom = computeNewZoom(current, min, max, step, factor, direction)
 
     // then
-    expect(newZoom).toBeDefined()
     expect(newZoom).toStrictEqual(current)
   })
 })

--- a/src/components/layout/form/fields/tests/DateField.spec.jsx
+++ b/src/components/layout/form/fields/tests/DateField.spec.jsx
@@ -6,7 +6,7 @@ import { Form } from 'react-final-form'
 import DateField from '../DateField'
 
 describe('src | components | layout | form | DateField', () => {
-  it('should match snapchot', () => {
+  it('should match the snapchot', () => {
     // given
     const initialValues = {
       myDate: '2019-04-27T20:00:00Z',
@@ -32,7 +32,6 @@ describe('src | components | layout | form | DateField', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/form/fields/tests/HiddenField.spec.jsx
+++ b/src/components/layout/form/fields/tests/HiddenField.spec.jsx
@@ -6,7 +6,7 @@ import HiddenField from '../HiddenField'
 import TextField from '../TextField'
 
 describe('src | components | layout | form | HiddenField', () => {
-  it('should match snapchot', () => {
+  it('should match the snapchot', () => {
     // given
     const initialValues = {
       subtitle: 'Mais jamais sans mon cadis.',
@@ -34,7 +34,6 @@ describe('src | components | layout | form | HiddenField', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/form/fields/tests/NumberField.spec.jsx
+++ b/src/components/layout/form/fields/tests/NumberField.spec.jsx
@@ -5,7 +5,7 @@ import { Form } from 'react-final-form'
 import NumberField from '../NumberField'
 
 describe('src | components | layout | form | NumberField', () => {
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // given
     const initialValues = {
       bar: 3,
@@ -33,7 +33,6 @@ describe('src | components | layout | form | NumberField', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/form/fields/tests/TextField.spec.jsx
+++ b/src/components/layout/form/fields/tests/TextField.spec.jsx
@@ -5,7 +5,7 @@ import { Form } from 'react-final-form'
 import TextField from '../TextField'
 
 describe('src | components | layout | form | TextField', () => {
-  it('should match snapchot', () => {
+  it('should match the snapchot', () => {
     // given
     const initialValues = {
       text: 'Ca parle de canapés.',
@@ -33,7 +33,6 @@ describe('src | components | layout | form | TextField', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/form/fields/tests/TimeField.spec.jsx
+++ b/src/components/layout/form/fields/tests/TimeField.spec.jsx
@@ -6,7 +6,7 @@ import DateField from '../DateField'
 import TimeField from '../TimeField'
 
 describe('src | components | layout | form | TimeField', () => {
-  it('should match snapchot', () => {
+  it('should match the snapchot', () => {
     // given
     const initialValues = {
       myDate: '2019-04-27T20:00:00Z',
@@ -33,7 +33,6 @@ describe('src | components | layout | form | TimeField', () => {
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/layout/form/fields/tests/__snapshots__/DateField.spec.jsx.snap
+++ b/src/components/layout/form/fields/tests/__snapshots__/DateField.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | form | DateField should match snapchot 1`] = `
+exports[`src | components | layout | form | DateField should match the snapchot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReactFinalForm

--- a/src/components/layout/form/fields/tests/__snapshots__/HiddenField.spec.jsx.snap
+++ b/src/components/layout/form/fields/tests/__snapshots__/HiddenField.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | form | HiddenField should match snapchot 1`] = `
+exports[`src | components | layout | form | HiddenField should match the snapchot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReactFinalForm

--- a/src/components/layout/form/fields/tests/__snapshots__/NumberField.spec.jsx.snap
+++ b/src/components/layout/form/fields/tests/__snapshots__/NumberField.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | form | NumberField should match snapshot 1`] = `
+exports[`src | components | layout | form | NumberField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReactFinalForm

--- a/src/components/layout/form/fields/tests/__snapshots__/TextField.spec.jsx.snap
+++ b/src/components/layout/form/fields/tests/__snapshots__/TextField.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | form | TextField should match snapchot 1`] = `
+exports[`src | components | layout | form | TextField should match the snapchot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReactFinalForm

--- a/src/components/layout/form/fields/tests/__snapshots__/TimeField.spec.jsx.snap
+++ b/src/components/layout/form/fields/tests/__snapshots__/TimeField.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | layout | form | TimeField should match snapchot 1`] = `
+exports[`src | components | layout | form | TimeField should match the snapchot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReactFinalForm

--- a/src/components/pages/Desk/DeskState/__specs__/DeskState.spec.jsx
+++ b/src/components/pages/Desk/DeskState/__specs__/DeskState.spec.jsx
@@ -22,15 +22,12 @@ describe('src | components | pages | Desk | DeskState ', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<DeskState {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<DeskState {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Desk/DeskState/__specs__/__snapshots__/DeskState.spec.jsx.snap
+++ b/src/components/pages/Desk/DeskState/__specs__/__snapshots__/DeskState.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Desk | DeskState  snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Desk | DeskState  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <DeskState

--- a/src/components/pages/Desk/__specs__/Desk.spec.js
+++ b/src/components/pages/Desk/__specs__/Desk.spec.js
@@ -20,7 +20,7 @@ describe('src | components | pages | Desk | Desk ', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Desk {...props} />, options)
 

--- a/src/components/pages/Desk/__specs__/__snapshots__/Desk.spec.js.snap
+++ b/src/components/pages/Desk/__specs__/__snapshots__/Desk.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Desk | Desk  should match snapshot 1`] = `
+exports[`src | components | pages | Desk | Desk  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Desk

--- a/src/components/pages/Offer/MediationsManager/MediationItem/__specs__/MediationItem.spec.jsx
+++ b/src/components/pages/Offer/MediationsManager/MediationItem/__specs__/MediationItem.spec.jsx
@@ -17,15 +17,12 @@ describe('src | components | pages | Offer | MediationItem', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<MediationItem {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<MediationItem {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Offer/MediationsManager/MediationItem/__specs__/__snapshots__/MediationItem.spec.jsx.snap
+++ b/src/components/pages/Offer/MediationsManager/MediationItem/__specs__/__snapshots__/MediationItem.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offer | MediationItem snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offer | MediationItem should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <MediationItem

--- a/src/components/pages/Offer/MediationsManager/__specs__/MediationsManager.spec.jsx
+++ b/src/components/pages/Offer/MediationsManager/__specs__/MediationsManager.spec.jsx
@@ -29,7 +29,6 @@ describe('src | components | pages | Offer | MediationsManager | MediationsManag
     const wrapper = shallow(<MediationsManager {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.js
@@ -34,7 +34,6 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
     const wrapper = shallow(<StockItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/DeleteDialog.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/DeleteDialog.spec.js
@@ -5,7 +5,7 @@ import DeleteDialog from '../DeleteDialog'
 
 describe('src | components | pages | Offer | StockItem | DeleteDialog', () => {
   describe('snapshot', () => {
-    it('should match snapshot when isEvent = true', () => {
+    it('should match the snapshot when isEvent = true', () => {
       // given
       const initialProps = {
         isEvent: true,
@@ -15,11 +15,10 @@ describe('src | components | pages | Offer | StockItem | DeleteDialog', () => {
       const wrapper = shallow(<DeleteDialog {...initialProps} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
-    it('should match snapshot when isEvent = false', () => {
+    it('should match the snapshot when isEvent = false', () => {
       // given
       const initialProps = {
         isEvent: false,
@@ -29,7 +28,6 @@ describe('src | components | pages | Offer | StockItem | DeleteDialog', () => {
       const wrapper = shallow(<DeleteDialog {...initialProps} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
   })

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/__snapshots__/DeleteDialog.spec.js.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/DeleteDialog/__specs__/__snapshots__/DeleteDialog.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offer | StockItem | DeleteDialog snapshot should match snapshot when isEvent = false 1`] = `
+exports[`src | components | pages | Offer | StockItem | DeleteDialog snapshot should match the snapshot when isEvent = false 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <DeleteDialog
@@ -306,7 +306,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Offer | StockItem | DeleteDialog snapshot should match snapshot when isEvent = true 1`] = `
+exports[`src | components | pages | Offer | StockItem | DeleteDialog snapshot should match the snapshot when isEvent = true 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <DeleteDialog

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/EditAndDeleteControl.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/EditAndDeleteControl.spec.js
@@ -44,7 +44,6 @@ describe('src | components | pages | Offer | StockManager | StockItem | sub-comp
     )
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/SubmitAndCancelControl/__specs__/SubmitAndCancelControl.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/SubmitAndCancelControl/__specs__/SubmitAndCancelControl.spec.js
@@ -5,23 +5,20 @@ import { Field, Form } from 'react-final-form'
 import SubmitAndCancelControl from '../SubmitAndCancelControl'
 
 describe('src | components | pages | Offer | StocksManagerContainer | StockItem | SubmitAndCancelControl ', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialProps = {
-        form: {},
-        handleSubmit: () => jest.fn(),
-        isRequestPending: false,
-        query: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const initialProps = {
+      form: {},
+      handleSubmit: () => jest.fn(),
+      isRequestPending: false,
+      query: {},
+    }
 
-      // when
-      const wrapper = shallow(<SubmitAndCancelControl {...initialProps} />)
+    // when
+    const wrapper = shallow(<SubmitAndCancelControl {...initialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('mount', () => {

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/SubmitAndCancelControl/__specs__/__snapshots__/SubmitAndCancelControl.spec.js.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/SubmitAndCancelControl/__specs__/__snapshots__/SubmitAndCancelControl.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offer | StocksManagerContainer | StockItem | SubmitAndCancelControl  snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offer | StocksManagerContainer | StockItem | SubmitAndCancelControl  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SubmitAndCancelControl

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/EventFields.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/EventFields.spec.js
@@ -4,21 +4,18 @@ import React from 'react'
 import EventFields from '../EventFields'
 
 describe('src | components | pages | Offer | StockItem | EventFields', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialProps = {
-        beginningMinDate: '2019-03-29T01:56:55.610Z',
-        dispatch: jest.fn(),
-        parseFormChild: jest.fn(),
-      }
+  it('should match the snapshot', () => {
+    // given
+    const initialProps = {
+      beginningMinDate: '2019-03-29T01:56:55.610Z',
+      dispatch: jest.fn(),
+      parseFormChild: jest.fn(),
+    }
 
-      // when
-      const wrapper = shallow(<EventFields {...initialProps} />)
+    // when
+    const wrapper = shallow(<EventFields {...initialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/__snapshots__/EventFields.spec.js.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/__snapshots__/EventFields.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offer | StockItem | EventFields snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offer | StockItem | EventFields should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <EventFields

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/ProductFields/__specs__/ProductFields.spec.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/ProductFields/__specs__/ProductFields.spec.js
@@ -19,7 +19,6 @@ describe('src | components | pages | Offer | StocksManager | StockItem | sub-com
     const wrapper = shallow(<ProductFields {...initialProps} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Offer/StocksManager/__specs__/StocksManager.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/__specs__/StocksManager.spec.jsx
@@ -49,7 +49,6 @@ describe('src | components | pages | Offer | StocksManager | StocksManager', () 
     const wrapper = shallow(<StocksManager {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Offer/__specs__/Offer.spec.jsx
+++ b/src/components/pages/Offer/__specs__/Offer.spec.jsx
@@ -8,38 +8,35 @@ import MediationsManager from '../MediationsManager/MediationsManagerContainer'
 describe('src | components | pages | Offer | Offer ', () => {
   const dispatch = jest.fn()
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const initialProps = {
-        location: {
-          search: '?lieu=AQ',
+  it('should match the snapshot', () => {
+    // given
+    const initialProps = {
+      location: {
+        search: '?lieu=AQ',
+      },
+      match: {
+        params: {
+          offerId: 'N9',
         },
-        match: {
-          params: {
-            offerId: 'N9',
-          },
-        },
-        currentUser: {
-          isAdmin: false,
-        },
-        isEditableOffer: true,
-        query: {
-          context: () => ({}),
-          parse: () => ({ lieu: 'AQ' }),
-          translate: () => ({ venue: 'AQ ' }),
-        },
-        dispatch: dispatch,
-        venues: [],
-      }
+      },
+      currentUser: {
+        isAdmin: false,
+      },
+      isEditableOffer: true,
+      query: {
+        context: () => ({}),
+        parse: () => ({ lieu: 'AQ' }),
+        translate: () => ({ venue: 'AQ ' }),
+      },
+      dispatch: dispatch,
+      venues: [],
+    }
 
-      // when
-      const wrapper = shallow(<Offer {...initialProps} />)
+    // when
+    const wrapper = shallow(<Offer {...initialProps} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('handleSuccess', () => {

--- a/src/components/pages/Offer/__specs__/__snapshots__/Offer.spec.jsx.snap
+++ b/src/components/pages/Offer/__specs__/__snapshots__/Offer.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offer | Offer  snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offer | Offer  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Offer

--- a/src/components/pages/Offerer/VenueItem/__specs__/VenueItem.spec.jsx
+++ b/src/components/pages/Offerer/VenueItem/__specs__/VenueItem.spec.jsx
@@ -21,15 +21,12 @@ describe('src | components | pages | Offerer | VenueItem', () => {
     history = createBrowserHistory()
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<VenueItem {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<VenueItem {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Offerer/VenueItem/__specs__/__snapshots__/VenueItem.spec.jsx.snap
+++ b/src/components/pages/Offerer/VenueItem/__specs__/__snapshots__/VenueItem.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offerer | VenueItem snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offerer | VenueItem should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VenueItem

--- a/src/components/pages/Offerers/OffererItem/__specs__/OffererItem.spec.jsx
+++ b/src/components/pages/Offerers/OffererItem/__specs__/OffererItem.spec.jsx
@@ -44,7 +44,6 @@ describe('src | components | pages | Offerers | OffererItem | OffererItem', () =
     const wrapper = shallow(<OffererItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Offerers/OffererItem/__specs__/PendingOffererItem.spec.jsx
+++ b/src/components/pages/Offerers/OffererItem/__specs__/PendingOffererItem.spec.jsx
@@ -12,14 +12,11 @@ describe('src | components | pages | Offerers | OffererItem | PendingOffererItem
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<PendingOffererItem {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<PendingOffererItem {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Offerers/OffererItem/__specs__/__snapshots__/PendingOffererItem.spec.jsx.snap
+++ b/src/components/pages/Offerers/OffererItem/__specs__/__snapshots__/PendingOffererItem.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offerers | OffererItem | PendingOffererItem snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offerers | OffererItem | PendingOffererItem should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <PendingOffererItem

--- a/src/components/pages/Offerers/__specs__/Offerers.spec.jsx
+++ b/src/components/pages/Offerers/__specs__/Offerers.spec.jsx
@@ -32,12 +32,11 @@ describe('src | components | pages | Offerers | Offerers', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Offerers {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -71,7 +70,7 @@ describe('src | components | pages | Offerers | Offerers', () => {
         expect(heroSection.title).toStrictEqual('Vos structures juridiques')
       })
     })
-    
+
     describe('when leaving page', () => {
       it('should not close notifcation', () => {
         // given

--- a/src/components/pages/Offerers/__specs__/__snapshots__/Offerers.spec.jsx.snap
+++ b/src/components/pages/Offerers/__specs__/__snapshots__/Offerers.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offerers | Offerers should match snapshot 1`] = `
+exports[`src | components | pages | Offerers | Offerers should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Offerers

--- a/src/components/pages/Offers/OfferItem/__specs__/OfferItem.spec.js
+++ b/src/components/pages/Offers/OfferItem/__specs__/OfferItem.spec.js
@@ -83,7 +83,6 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
         // then
         const thumbComponent = wrapper.find(Thumb)
-        expect(thumbComponent).toBeDefined()
         expect(thumbComponent.prop('alt')).toBe('offre')
         expect(thumbComponent.prop('src')).toBe('https://url.to/thumb')
       })
@@ -98,7 +97,6 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
         // then
         const thumbComponent = wrapper.find(Thumb)
-        expect(thumbComponent).toBeDefined()
         expect(thumbComponent.prop('alt')).toBe('offre')
         expect(thumbComponent.prop('src')).toBe('')
       })
@@ -116,12 +114,10 @@ describe('src | components | pages | Offers | OfferItem', () => {
 
       // then
       const navLinkComponent = wrapper.find(NavLink).first()
-      expect(navLinkComponent).toBeDefined()
       expect(navLinkComponent.prop('className')).toBe('name')
       expect(navLinkComponent.prop('to')).toBe('/offres/M4?orderBy=offer.id+desc')
       expect(navLinkComponent.prop('title')).toBe('fake name')
       const dotdotdotComponent = navLinkComponent.find(Dotdotdot)
-      expect(dotdotdotComponent).toBeDefined()
       expect(dotdotdotComponent.prop('clamp')).toBe(1)
       expect(dotdotdotComponent.html()).toBe('<div>fake name</div>')
     })
@@ -194,7 +190,6 @@ describe('src | components | pages | Offers | OfferItem', () => {
       expect(offerInfosSubElements.at(0).prop('title')).toBe('entre 1 et 5 personnes')
 
       const userPictoComponent = offerInfosSubElements.at(0).find(Icon)
-      expect(userPictoComponent).toBeDefined()
       expect(userPictoComponent.prop('svg')).toBe('picto-user')
     })
 
@@ -217,7 +212,6 @@ describe('src | components | pages | Offers | OfferItem', () => {
       expect(offerInfosSubElements.at(0).prop('title')).toBe('entre 2 et 5 personnes')
 
       const userPictoComponent = offerInfosSubElements.at(0).find(Icon)
-      expect(userPictoComponent).toBeDefined()
       expect(userPictoComponent.prop('svg')).toBe('picto-group')
 
       const numberOfParticipantsLabel = offerInfosSubElements.at(0).find('p')

--- a/src/components/pages/Offers/__specs__/Offers.spec.jsx
+++ b/src/components/pages/Offers/__specs__/Offers.spec.jsx
@@ -46,17 +46,14 @@ describe('src | components | pages | Offers | Offers', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Offers {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Offers {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-      dispatch.mockClear()
-      change.mockClear()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
+    dispatch.mockClear()
+    change.mockClear()
   })
 
   describe('render', () => {
@@ -78,7 +75,7 @@ describe('src | components | pages | Offers | Offers', () => {
       })
     })
 
-    describe('Offerer filter button', () => {
+    describe('offerer filter button', () => {
       it('should be displayed when offerer is given', () => {
         // given
         props.offerer = {
@@ -487,7 +484,6 @@ describe('src | components | pages | Offers | Offers', () => {
 
     describe('componentDidMount', () => {
       it('should dispatch handleRequestData when there is no pagination', () => {
-        console.log();
         // when
         const wrapper = shallow(<Offers {...props} />)
         wrapper.instance().componentDidMount()

--- a/src/components/pages/Offers/__specs__/__snapshots__/Offers.spec.jsx.snap
+++ b/src/components/pages/Offers/__specs__/__snapshots__/Offers.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Offers | Offers snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Offers | Offers should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Offers

--- a/src/components/pages/Profil/tests/Profil.spec.jsx
+++ b/src/components/pages/Profil/tests/Profil.spec.jsx
@@ -20,12 +20,11 @@ describe('src | components | pages | Profil', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<Profil {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Profil/tests/__snapshots__/Profil.spec.jsx.snap
+++ b/src/components/pages/Profil/tests/__snapshots__/Profil.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Profil should match snapshot 1`] = `
+exports[`src | components | pages | Profil should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Profil

--- a/src/components/pages/Reimbursements/__specs__/Reimbursements.spec.jsx
+++ b/src/components/pages/Reimbursements/__specs__/Reimbursements.spec.jsx
@@ -8,15 +8,12 @@ import { API_URL } from '../../../../utils/config'
 import DisplayButtonContainer from '../../../layout/CsvTableButton/CsvTableButtonContainer'
 
 describe('src | components | pages | Reimbursements', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Reimbursements />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Reimbursements />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Reimbursements/__specs__/__snapshots__/Reimbursements.spec.jsx.snap
+++ b/src/components/pages/Reimbursements/__specs__/__snapshots__/Reimbursements.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Reimbursements snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Reimbursements should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Reimbursements />,

--- a/src/components/pages/Signin/__specs__/Signin.spec.js
+++ b/src/components/pages/Signin/__specs__/Signin.spec.js
@@ -28,7 +28,6 @@ describe('src | components | pages | Signin | Signin ', () => {
     const wrapper = shallow(<Signin {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Signup/SignupValidation/__specs__/SignupValidation.spec.js
+++ b/src/components/pages/Signup/SignupValidation/__specs__/SignupValidation.spec.js
@@ -22,12 +22,11 @@ describe('src | components | pages | Signup | validation', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<SignupValidation {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Signup/SignupValidation/__specs__/__snapshots__/SignupValidation.spec.js.snap
+++ b/src/components/pages/Signup/SignupValidation/__specs__/__snapshots__/SignupValidation.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Signup | validation should match snapshot 1`] = `
+exports[`src | components | pages | Signup | validation should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <SignupValidation

--- a/src/components/pages/Signup/__specs__/Signup.spec.jsx
+++ b/src/components/pages/Signup/__specs__/Signup.spec.jsx
@@ -4,19 +4,16 @@ import React from 'react'
 import Signup from '../Signup'
 
 describe('src | components | pages | Signup', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        errors: {},
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      errors: {},
+    }
 
-      // when
-      const wrapper = shallow(<Signup {...props} />)
+    // when
+    const wrapper = shallow(<Signup {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Signup/__specs__/__snapshots__/Signup.spec.jsx.snap
+++ b/src/components/pages/Signup/__specs__/__snapshots__/Signup.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Signup snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Signup should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Signup

--- a/src/components/pages/Venue/VenueProvidersManager/VenueProviderItem/__specs__/VenueProviderItem.spec.js
+++ b/src/components/pages/Venue/VenueProvidersManager/VenueProviderItem/__specs__/VenueProviderItem.spec.js
@@ -24,12 +24,11 @@ describe('src | components | pages | Venue | VenueProvidersManager | VenueProvid
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<VenueProviderItem {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -83,11 +82,9 @@ describe('src | components | pages | Venue | VenueProvidersManager | VenueProvid
 
       // then
       const navLink = wrapper.find(NavLink)
-      expect(navLink).toBeDefined()
       expect(navLink.prop('to')).toBe('/offres?lieu=1')
       expect(navLink.prop('className')).toBe('has-text-primary')
       const icon = navLink.find(Icon)
-      expect(icon).toBeDefined()
       expect(icon.prop('svg')).toBe('ico-offres-r')
       const numberOfOffersLabel = navLink.find('.number-of-offers-label')
       expect(numberOfOffersLabel).toHaveLength(1)

--- a/src/components/pages/Venue/VenueProvidersManager/VenueProviderItem/__specs__/__snapshots__/VenueProviderItem.spec.js.snap
+++ b/src/components/pages/Venue/VenueProvidersManager/VenueProviderItem/__specs__/__snapshots__/VenueProviderItem.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | VenueProvidersManager | VenueProviderItem should match snapshot 1`] = `
+exports[`src | components | pages | Venue | VenueProvidersManager | VenueProviderItem should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <VenueProviderItem

--- a/src/components/pages/Venue/VenueProvidersManager/__specs__/VenueProvidersManager.spec.js
+++ b/src/components/pages/Venue/VenueProvidersManager/__specs__/VenueProvidersManager.spec.js
@@ -84,7 +84,6 @@ describe('src | components | pages | Venue | VenueProvidersManager', () => {
 
       // then
       const title = wrapper.find('h2')
-      expect(title).toBeDefined()
       const span = title.find('span')
       expect(span.text()).toBe(
         'Si vous avez plusieurs comptes auprès de la même source, ajoutez-les successivement.'
@@ -304,7 +303,6 @@ describe('src | components | pages | Venue | VenueProvidersManager', () => {
 
       // then
       const form = wrapper.find(Form)
-      expect(form).toBeDefined()
       expect(form.prop('decorators')).toStrictEqual(expect.anything())
       expect(form.prop('initialValues')).toStrictEqual({ id: 'AB' })
       expect(form.prop('onSubmit')).toStrictEqual(expect.any(Function))

--- a/src/components/pages/Venue/VenueProvidersManager/form/VenueProviderForm/__specs__/VenueProviderForm.spec.js
+++ b/src/components/pages/Venue/VenueProvidersManager/form/VenueProviderForm/__specs__/VenueProviderForm.spec.js
@@ -31,7 +31,6 @@ describe('src | components | pages | Venue | VenueProvidersManager | form | Venu
 
     // then
     const icon = wrapper.find(Icon).first()
-    expect(icon).toBeDefined()
     expect(icon.prop('svg')).toBe('picto-db-default')
     expect(icon.prop('alt')).toBe('Choix de la source')
   })
@@ -42,7 +41,6 @@ describe('src | components | pages | Venue | VenueProvidersManager | form | Venu
 
     // then
     const hiddenField = wrapper.find(HiddenField)
-    expect(hiddenField).toBeDefined()
     expect(hiddenField.prop('name')).toBe('id')
   })
 

--- a/src/components/pages/Venue/__specs__/Venue.spec.jsx
+++ b/src/components/pages/Venue/__specs__/Venue.spec.jsx
@@ -47,15 +47,12 @@ describe('src | components | pages | Venue', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<Venue {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<Venue {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {
@@ -110,7 +107,6 @@ describe('src | components | pages | Venue', () => {
 
         // then
         const heroSection = wrapper.find(HeroSection)
-        expect(heroSection.find('p')).toBeDefined()
         expect(heroSection.find('p').prop('className')).toBe('subtitle')
         expect(heroSection.find('p').text()).toBe('Ajoutez un lieu où accéder à vos offres.')
       })

--- a/src/components/pages/Venue/__specs__/__snapshots__/Venue.spec.jsx.snap
+++ b/src/components/pages/Venue/__specs__/__snapshots__/Venue.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Venue

--- a/src/components/pages/Venue/controls/CreateControl/__specs__/CreateControl.spec.jsx
+++ b/src/components/pages/Venue/controls/CreateControl/__specs__/CreateControl.spec.jsx
@@ -12,12 +12,11 @@ describe('src | components | pages | Venue | controls | CreateControl ', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<CreateControl {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Venue/controls/CreateControl/__specs__/__snapshots__/CreateControl.spec.jsx.snap
+++ b/src/components/pages/Venue/controls/CreateControl/__specs__/__snapshots__/CreateControl.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | controls | CreateControl  should match snapshot 1`] = `
+exports[`src | components | pages | Venue | controls | CreateControl  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <CreateControl

--- a/src/components/pages/Venue/controls/ModifyOrCancelControl/__specs__/ModifyOrCancelControl.spec.jsx
+++ b/src/components/pages/Venue/controls/ModifyOrCancelControl/__specs__/ModifyOrCancelControl.spec.jsx
@@ -9,26 +9,23 @@ const history = {
 }
 
 describe('src | components | pages | Venue | controls | ModifyOrCancelControl ', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // given
-      const props = {
-        form: {},
-        handleSubmit: jest.fn(),
-        history,
-        isCreatedEntity: true,
-        offererId: 'AE',
-        readOnly: false,
-        venueId: 'AE',
-      }
+  it('should match the snapshot', () => {
+    // given
+    const props = {
+      form: {},
+      handleSubmit: jest.fn(),
+      history,
+      isCreatedEntity: true,
+      offererId: 'AE',
+      readOnly: false,
+      venueId: 'AE',
+    }
 
-      // when
-      const wrapper = shallow(<ModifyOrCancelControl {...props} />)
+    // when
+    const wrapper = shallow(<ModifyOrCancelControl {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('mount', () => {

--- a/src/components/pages/Venue/controls/ModifyOrCancelControl/__specs__/__snapshots__/ModifyOrCancelControl.spec.jsx.snap
+++ b/src/components/pages/Venue/controls/ModifyOrCancelControl/__specs__/__snapshots__/ModifyOrCancelControl.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | controls | ModifyOrCancelControl  snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | controls | ModifyOrCancelControl  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ModifyOrCancelControl

--- a/src/components/pages/Venue/controls/ReturnOrSubmitControl/__specs__/ReturnOrSubmitControl.spec.jsx
+++ b/src/components/pages/Venue/controls/ReturnOrSubmitControl/__specs__/ReturnOrSubmitControl.spec.jsx
@@ -16,15 +16,12 @@ describe('src | components | pages | Venue | controls | ReturnOrSubmitControl ',
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<ReturnOrSubmitControl {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<ReturnOrSubmitControl {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Venue/controls/ReturnOrSubmitControl/__specs__/__snapshots__/ReturnOrSubmitControl.spec.jsx.snap
+++ b/src/components/pages/Venue/controls/ReturnOrSubmitControl/__specs__/__snapshots__/ReturnOrSubmitControl.spec.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | controls | ReturnOrSubmitControl  snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | controls | ReturnOrSubmitControl  should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <ReturnOrSubmitControl

--- a/src/components/pages/Venue/fields/BankFields/__specs__/BankFields.spec.js
+++ b/src/components/pages/Venue/fields/BankFields/__specs__/BankFields.spec.js
@@ -15,15 +15,12 @@ describe('src | components | pages | Venue | fields | BankFields', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<BankFields {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<BankFields {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Venue/fields/BankFields/__specs__/__snapshots__/BankFields.spec.js.snap
+++ b/src/components/pages/Venue/fields/BankFields/__specs__/__snapshots__/BankFields.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | fields | BankFields snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | BankFields should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <BankFields

--- a/src/components/pages/Venue/fields/IdentifierFields/__specs__/IdentifierFields.spec.js
+++ b/src/components/pages/Venue/fields/IdentifierFields/__specs__/IdentifierFields.spec.js
@@ -18,15 +18,12 @@ describe('src | components | pages | Venue | fields | IdentifierFields', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<IdentifierFields {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<IdentifierFields {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('render', () => {

--- a/src/components/pages/Venue/fields/IdentifierFields/__specs__/__snapshots__/IdentifierFields.spec.js.snap
+++ b/src/components/pages/Venue/fields/IdentifierFields/__specs__/__snapshots__/IdentifierFields.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | fields | IdentifierFields snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | IdentifierFields should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <IdentifierFields

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/AddressField.spec.js
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/AddressField.spec.js
@@ -14,15 +14,12 @@ describe('src | components | pages | Venue | fields | AddressField', () => {
     }
   })
 
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<AddressField {...props} />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<AddressField {...props} />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 
   describe('addressFieldRender', () => {
@@ -48,12 +45,11 @@ describe('src | components | pages | Venue | fields | AddressField', () => {
       meta = {}
     })
 
-    it('should match snapshot', () => {
+    it('should match the snapshot', () => {
       // when
       const wrapper = shallow(<AddressFieldRender {...props} />)
 
       // then
-      expect(wrapper).toBeDefined()
       expect(wrapper).toMatchSnapshot()
     })
 
@@ -63,7 +59,6 @@ describe('src | components | pages | Venue | fields | AddressField', () => {
 
       // then
       const mainDiv = wrapper.find('div').first()
-      expect(mainDiv).toBeDefined()
       expect(mainDiv.prop('className')).toBe(
         'field text-field fake className is-label-aligned is-read-only'
       )
@@ -79,11 +74,9 @@ describe('src | components | pages | Venue | fields | AddressField', () => {
 
       // then
       const label = wrapper.find('label')
-      expect(label).toBeDefined()
       expect(label.prop('htmlFor')).toBe('fake name')
       expect(label.prop('className')).toBe('field-label')
       const spans = label.find('span')
-      expect(spans).toBeDefined()
       expect(spans).toHaveLength(3)
       expect(spans.at(1).text()).toBe('fake label')
       expect(spans.at(2).prop('className')).toBe('field-asterisk')
@@ -137,7 +130,6 @@ describe('src | components | pages | Venue | fields | AddressField', () => {
 
       // then
       const fieldErrors = wrapper.find(FieldErrors)
-      expect(fieldErrors).toBeDefined()
       expect(fieldErrors.prop('meta')).toStrictEqual({})
     })
   })

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/LocationFields.spec.js
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/LocationFields.spec.js
@@ -20,12 +20,11 @@ describe('src | components | pages | Venue | fields | LocationFields', () => {
     }
   })
 
-  it('should match snapshot', () => {
+  it('should match the snapshot', () => {
     // when
     const wrapper = shallow(<LocationFields {...props} />)
 
     // then
-    expect(wrapper).toBeDefined()
     expect(wrapper).toMatchSnapshot()
   })
 

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/LocationViewer.spec.js
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/LocationViewer.spec.js
@@ -3,14 +3,11 @@ import LocationViewer from '../LocationViewer'
 import React from 'react'
 
 describe('src | components | pages | Venue | fields | LocationViewer', () => {
-  describe('snapshot', () => {
-    it('should match snapshot', () => {
-      // when
-      const wrapper = shallow(<LocationViewer />)
+  it('should match the snapshot', () => {
+    // when
+    const wrapper = shallow(<LocationViewer />)
 
-      // then
-      expect(wrapper).toBeDefined()
-      expect(wrapper).toMatchSnapshot()
-    })
+    // then
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/AddressField.spec.js.snap
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/AddressField.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | fields | AddressField addressFieldRender should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | AddressField addressFieldRender should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <Unknown
@@ -58,7 +58,7 @@ ShallowWrapper {
 }
 `;
 
-exports[`src | components | pages | Venue | fields | AddressField snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | AddressField should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <AddressField

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/LocationFields.spec.js.snap
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/LocationFields.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | fields | LocationFields should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | LocationFields should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <LocationFields

--- a/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/LocationViewer.spec.js.snap
+++ b/src/components/pages/Venue/fields/LocationFields/__specs__/__snapshots__/LocationViewer.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`src | components | pages | Venue | fields | LocationViewer snapshot should match snapshot 1`] = `
+exports[`src | components | pages | Venue | fields | LocationViewer should match the snapshot 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <LocationViewer


### PR DESCRIPTION
- Suppression de `toBeDefined` dans les tests quand ce n'est pas nécessaire (tel que décider en rétro tech) ;
- Renommage de `should match snapshot` en `should match the snapshot` (d'où le fait que les snapshots ont changés) ;
- Suppression de `describe('snapshot', () => {` quand inutile ;