### PR TITLE
(PC-2721) fix UI on warning message on digital offer reimbursement

### DIFF
--- a/src/components/pages/Offer/Offer.jsx
+++ b/src/components/pages/Offer/Offer.jsx
@@ -396,7 +396,10 @@ class Offer extends PureComponent {
 
     const offererHasNoPhysicalVenues = offerer && get(venuesMatchingOfferType, 'length') === 0
 
-    const isDisplayDigitalOfferInformationMessage = displayDigitalOfferInformationMessage(selectedOfferType, venue)
+    const isDisplayDigitalOfferInformationMessage = displayDigitalOfferInformationMessage(
+      selectedOfferType,
+      venue
+    )
 
     return (
       <Main
@@ -610,23 +613,26 @@ class Offer extends PureComponent {
               </div>
               {isDisplayDigitalOfferInformationMessage && (
                 <div className="is-horizontal">
-                  <Insert className="yellow-insert">
+                  <Insert className="yellow-insert ">
                     <p>
                       {
-                        "Les offres numériques (à l'expection des livres numériques) ne feront pas l'objet d'un remboursement. Pour plus d'informations, merci de consulter les CGU."
+                        "Les offres numériques (à l'exception des livres numériques) ne feront pas l'objet d'un remboursement. Pour plus d'informations, merci de consulter les CGU."
                       }
                     </p>
-                    <span className="icon">
-                      <Icon svg="ico-external-site" />
-                    </span>
-                    <a
-                      href={CGU_URL}
-                      id="cgu-link"
-                      rel="noopener noreferrer"
-                      target="_blank"
-                    >
-                      {"Consulter les Conditions Générales d'utilisation"}
-                    </a>
+
+                    <div className="insert-action-link">
+                      <a
+                        href={CGU_URL}
+                        id="cgu-link"
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <Icon svg="ico-external-site" />
+                      </a>
+                      <p>
+                        {"Consulter les Conditions Générales d'Utilisation"}
+                      </p>
+                    </div>
                   </Insert>
                 </div>
               )}

--- a/src/styles/components/layout/Insert/_Insert.scss
+++ b/src/styles/components/layout/Insert/_Insert.scss
@@ -22,19 +22,26 @@
 .yellow-insert {
   @extend .fs16;
 
-  align-items: center;
   background-color: #ffea00;
   border-radius: 6px;
+  display: flex;
   margin-bottom: 1.5rem;
   padding: 18px;
 
-  a {
-    font-weight: 700;
-    margin-left: 8px;
-  }
+  .insert-action-link {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: start;
 
-  img {
-    height: auto;
-    padding-top: 0.2rem;
+    p {
+      align-self: center;
+      font-weight: 700;
+      padding-left: 0.5rem;
+    }
+
+    img {
+      align-self: center;
+    }
   }
 }

--- a/src/styles/components/layout/Insert/_Insert.scss
+++ b/src/styles/components/layout/Insert/_Insert.scss
@@ -35,9 +35,10 @@
     justify-content: start;
 
     p {
-      align-self: center;
+      align-self: normal;
       font-weight: 700;
       padding-left: 0.5rem;
+      padding-top: 0.25rem;
     }
 
     img {


### PR DESCRIPTION
 - Ajouter une majuscule à “Utilisation”
- Corriger le texte “à l’exception”
-  L’icône devrait etre cliquable aussi, elle fait parti du bouton
- L’icône devrait etre cliquable aussi, elle fait parti du bouton