### PR TITLE
(PC-2618): bugfix delete warning message on consistency between venue type and offer type

### DIFF
--- a/src/components/pages/Offer/Offer.jsx
+++ b/src/components/pages/Offer/Offer.jsx
@@ -4,7 +4,6 @@ import {
   Field,
   Form,
   Icon,
-  mergeErrors,
   mergeForm,
   pluralize,
   resetForm,
@@ -76,12 +75,10 @@ class Offer extends PureComponent {
   componentDidUpdate(prevProps) {
     const {
       dispatch,
-      formInitialValues,
       formOffererId,
       formVenueId,
       location,
       offerer,
-      offerTypeError,
       selectedOfferType,
       venue,
     } = this.props
@@ -115,15 +112,6 @@ class Offer extends PureComponent {
 
     this.setDefaultBookingEmailIfNew(prevProps)
 
-    if (get(formInitialValues, 'type') && !selectedOfferType && !offerTypeError) {
-      dispatch(
-        mergeErrors('offer', {
-          type: [
-            'Il y a eu un problème avec la création de cette offre : son type est incompatible avec le lieu enregistré.',
-          ],
-        })
-      )
-    }
     this.setDefaultIsDuoIfNewAndEvent()
 
     this.forceReactToolTip()


### PR DESCRIPTION
Pour expliquer un peu la PR : 

*Bug*
Le message : "Il y a eu un problème sur la création de cette offre : son type est incompatible avec le lieu enregistré" apparaissait sous le champs "type" d'une offre "cinéma vente à distance". Lorsque l'offre était chargé directement (en naviguant directement sur l'url).

Exemple : https://pro.passculture-testing.beta.gouv.fr/offres/HAHQ?lieu=AFEQ&mots-cles=carte%20cinema

*Resolution* 
Il s'avère que des nouvelles fonctionnalités passées (côté front sur le formulaire de creation et côté back sur la base de données) rendent ce cas impossible.

Du coup, on supprime la potentialité d'afficher ce message.