### PR TITLE
(PC-2882): Enable stock management for Allocine offers

### DIFF
--- a/src/components/pages/Offer/Offer.jsx
+++ b/src/components/pages/Offer/Offer.jsx
@@ -521,7 +521,7 @@ class Offer extends PureComponent {
                     </span>
                     <button
                       className="button is-primary is-outlined is-small manage-stock"
-                      disabled={isEditableOffer && !offerFromLocalProvider ? '' : 'disabled'}
+                      disabled={offerFromTiteLive ? 'disabled' : ''}
                       id="manage-stocks"
                       onClick={this.handleOnClick(query)}
                       type="button"

--- a/src/components/pages/Offer/OfferObject.js
+++ b/src/components/pages/Offer/OfferObject.js
@@ -1,10 +1,23 @@
 export default class OfferObject {
   constructor(offer = {}) {
-    this.id = offer.id || undefined
+    this.bookingEmail = offer.bookingEmail
+    this.dateCreated = offer.dateCreated
+    this.dateModifiedAtLastProvider = offer.dateModifiedAtLastProvider
+    this.isEvent = offer.isEvent
+    this.isThing = offer.isThing
+    this.id = offer.id
+    this.idAtProviders = offer.idAtProviders
+    this.isActive = offer.isActive
     this.lastProvider = offer.lastProvider || null
+    this.lastProviderId = offer.lastProviderId
+    this.mediationsIds = offer.mediationsIds
+    this.modelName = offer.modelName
+    this.productId = offer.productId
+    this.stocksIds = offer.stocksIds
+    this.venueId = offer.venueId
   }
 
   get hasBeenProvidedByAllocine() {
-    return this.lastProvider && this.lastProvider.name === 'Allociné'
+    return !!(this.lastProvider && this.lastProvider.name === 'Allociné')
   }
 }

--- a/src/components/pages/Offer/OfferObject.js
+++ b/src/components/pages/Offer/OfferObject.js
@@ -1,10 +1,10 @@
-export class OfferObject {
+export default class OfferObject {
   constructor(offer = {}) {
     this.id = offer.id || undefined
     this.lastProvider = offer.lastProvider || null
   }
 
   get hasBeenProvidedByAllocine() {
-    return this.lastProvider.name === 'Allociné'
+    return this.lastProvider && this.lastProvider.name === 'Allociné'
   }
 }

--- a/src/components/pages/Offer/OfferObject.js
+++ b/src/components/pages/Offer/OfferObject.js
@@ -1,0 +1,10 @@
+export class OfferObject {
+  constructor(offer = {}) {
+    this.id = offer.id || undefined
+    this.lastProvider = offer.lastProvider || null
+  }
+
+  get hasBeenProvidedByAllocine() {
+    return this.lastProvider.name === 'Allociné'
+  }
+}

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -82,7 +82,7 @@ class StockItem extends PureComponent {
   renderForm = formProps => {
     const {
       closeInfo,
-      dispatch,
+      deleteStock,
       hasIban,
       history,
       isEvent,
@@ -112,7 +112,6 @@ class StockItem extends PureComponent {
         {isEvent && (
           <EventFields
             beginningDatetime={beginningDatetime}
-            dispatch={dispatch}
             readOnly={userIsNotUpdatingStock || stockAssociatedToAllocineOffer}
             stockPatch={stockPatch}
             stocks={stocks}
@@ -134,7 +133,7 @@ class StockItem extends PureComponent {
         />
         {userIsNotUpdatingStock ? (
           <EditAndDeleteControl
-            dispatch={dispatch}
+            deleteStock={deleteStock}
             formInitialValues={stockPatch}
             handleSetErrors={handleSetErrors}
             history={history}
@@ -208,6 +207,7 @@ StockItem.defaultProps = {
 
 StockItem.propTypes = {
   closeInfo: PropTypes.func.isRequired,
+  deleteStock: PropTypes.func.isRequired,
   hasIban: PropTypes.bool.isRequired,
   history: PropTypes.shape().isRequired,
   isEvent: PropTypes.bool.isRequired,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -12,6 +12,7 @@ import fillEndDatimeWhenUpdatingBeginningDatetime from './decorators/fillEndDati
 import SubmitAndCancelControlContainer from './sub-components/SubmitAndCancelControl/SubmitAndCancelControlContainer'
 import { errorKeyToFrenchKey } from './utils/utils'
 import ProductFieldsContainer from './sub-components/fields/ProductFields/ProductFieldsContainer'
+import OfferObject from '../../OfferObject'
 
 class StockItem extends PureComponent {
   constructor(props) {
@@ -117,8 +118,7 @@ class StockItem extends PureComponent {
     // créer un état updating et ne plus passer par l'URL
     const { readOnly } = query.context({ id: stockId, key: 'stock' })
     const userIsNotUpdatingStock = readOnly
-    const stockAssociatingToAllocineOffer =
-      offer.lastProvider && offer.lastProvider.name === 'Allociné'
+    const stockAssociatingToAllocineOffer = offer.hasBeenProvidedByAllocine
     const { form, values, handleSubmit } = formProps
 
     const { beginningDatetime } = values
@@ -229,7 +229,7 @@ StockItem.propTypes = {
   hasIban: PropTypes.bool.isRequired,
   history: PropTypes.shape().isRequired,
   isEvent: PropTypes.bool.isRequired,
-  offer: PropTypes.shape(),
+  offer: PropTypes.instanceOf(OfferObject),
   query: PropTypes.shape().isRequired,
   showInfo: PropTypes.func.isRequired,
   stockPatch: PropTypes.shape().isRequired,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -101,7 +101,6 @@ class StockItem extends PureComponent {
     const { id: stockId } = stockPatch
     const { readOnly } = query.context({ id: stockId, key: 'stock' })
     const userIsNotUpdatingStock = readOnly
-    const stockAssociatedToAllocineOffer = offer.hasBeenProvidedByAllocine
     const { form, values, handleSubmit } = formProps
 
     const { beginningDatetime } = values
@@ -112,7 +111,7 @@ class StockItem extends PureComponent {
         {isEvent && (
           <EventFields
             beginningDatetime={beginningDatetime}
-            readOnly={userIsNotUpdatingStock || stockAssociatedToAllocineOffer}
+            readOnly={userIsNotUpdatingStock || offer.hasBeenProvidedByAllocine}
             stockPatch={stockPatch}
             stocks={stocks}
             timezone={timezone}

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -114,7 +114,11 @@ class StockItem extends PureComponent {
 
     const { isRequestPending, tbodyElement } = this.state
     const { id: stockId } = stockPatch
+    // créer un état updating et ne plus passer par l'URL
     const { readOnly } = query.context({ id: stockId, key: 'stock' })
+    const userIsNotUpdatingStock = readOnly
+    const stockAssociatingToAllocineOffer =
+      offer.lastProvider && offer.lastProvider.name === 'Allociné'
     const { form, values, handleSubmit } = formProps
 
     const { beginningDatetime } = values
@@ -126,7 +130,7 @@ class StockItem extends PureComponent {
           <EventFields
             beginningDatetime={beginningDatetime}
             dispatch={dispatch}
-            readOnly={readOnly}
+            readOnly={userIsNotUpdatingStock || stockAssociatingToAllocineOffer}
             stockPatch={stockPatch}
             stocks={stocks}
             timezone={timezone}
@@ -139,7 +143,7 @@ class StockItem extends PureComponent {
           hasIban={hasIban}
           isEvent={isEvent}
           offer={offer}
-          readOnly={readOnly}
+          readOnly={userIsNotUpdatingStock}
           showInfo={showInfo}
           stock={stock}
           timezone={timezone}

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -59,7 +59,7 @@ class StockItem extends PureComponent {
   }
 
   handleOnFormSubmit = formValues => {
-    const { updateStockInformations, handleSetErrors, stockPatch, isEvent } = this.props
+    const { handleSetErrors, stockPatch, isEvent, updateStockInformations } = this.props
     const { id: stockId } = stockPatch
     this.setState({ isRequestPending: true })
 
@@ -75,6 +75,7 @@ class StockItem extends PureComponent {
     if (isEvent && body.bookingLimitDatetime === '') {
       body.bookingLimitDatetime = body.beginningDatetime
     }
+
     return updateStockInformations(stockId, body, this.handleRequestSuccess, this.handleRequestFail)
   }
 
@@ -100,7 +101,7 @@ class StockItem extends PureComponent {
     const { id: stockId } = stockPatch
     const { readOnly } = query.context({ id: stockId, key: 'stock' })
     const userIsNotUpdatingStock = readOnly
-    const stockAssociatingToAllocineOffer = offer.hasBeenProvidedByAllocine
+    const stockAssociatedToAllocineOffer = offer.hasBeenProvidedByAllocine
     const { form, values, handleSubmit } = formProps
 
     const { beginningDatetime } = values
@@ -112,7 +113,7 @@ class StockItem extends PureComponent {
           <EventFields
             beginningDatetime={beginningDatetime}
             dispatch={dispatch}
-            readOnly={userIsNotUpdatingStock || stockAssociatingToAllocineOffer}
+            readOnly={userIsNotUpdatingStock || stockAssociatedToAllocineOffer}
             stockPatch={stockPatch}
             stocks={stocks}
             timezone={timezone}

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -34,12 +34,12 @@ class StockItem extends PureComponent {
     this.tbodyElement = element
   }
 
-  handleRequestFail = formResolver => (state, action) => {
+  handleRequestFail = (state, action) => {
     const { handleSetErrors } = this.props
     const {
       payload: { errors },
     } = action
-    const nextState = { isRequestPending: false }
+    this.setState({ isRequestPending: false })
     const frenchErrors = Object.keys(errors)
       .filter(errorKeyToFrenchKey)
       .reduce(
@@ -47,20 +47,15 @@ class StockItem extends PureComponent {
           Object.assign({ [errorKeyToFrenchKey(errorKey)]: errors[errorKey] }, result),
         null
       )
-    this.setState(nextState, () => {
-      handleSetErrors(frenchErrors)
-      formResolver
-    })
+    handleSetErrors(frenchErrors)
   }
 
-  handleRequestSuccess = formResolver => () => {
+  handleRequestSuccess = () => {
     const { query, stockPatch } = this.props
     const { id: stockId } = stockPatch
-    const nextState = { isRequestPending: false }
-    this.setState(nextState, () => {
-      query.changeToReadOnly(null, { id: stockId, key: 'stock' })
-      formResolver()
-    })
+
+    this.setState({ isRequestPending: false })
+    query.changeToReadOnly(null, { id: stockId, key: 'stock' })
   }
 
   handleOnFormSubmit = formValues => {
@@ -212,7 +207,6 @@ StockItem.defaultProps = {
 
 StockItem.propTypes = {
   closeInfo: PropTypes.func.isRequired,
-  dispatch: PropTypes.func.isRequired,
   hasIban: PropTypes.bool.isRequired,
   history: PropTypes.shape().isRequired,
   isEvent: PropTypes.bool.isRequired,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItem.jsx
@@ -11,7 +11,7 @@ import fillEndDatimeWhenUpdatingBeginningDatetime from './decorators/fillEndDati
 import SubmitAndCancelControlContainer from './sub-components/SubmitAndCancelControl/SubmitAndCancelControlContainer'
 import { errorKeyToFrenchKey } from './utils/utils'
 import ProductFieldsContainer from './sub-components/fields/ProductFields/ProductFieldsContainer'
-import OfferObject from '../../OfferObject'
+import Offer from '../../ValueObjects/Offer'
 
 class StockItem extends PureComponent {
   constructor(props) {
@@ -210,7 +210,7 @@ StockItem.propTypes = {
   hasIban: PropTypes.bool.isRequired,
   history: PropTypes.shape().isRequired,
   isEvent: PropTypes.bool.isRequired,
-  offer: PropTypes.instanceOf(OfferObject),
+  offer: PropTypes.instanceOf(Offer),
   query: PropTypes.shape().isRequired,
   showInfo: PropTypes.func.isRequired,
   stockPatch: PropTypes.shape().isRequired,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -79,10 +79,9 @@ export const mapStateToProps = (state, ownProps) => {
 }
 
 export const mapDispatchToProps = (dispatch, ownProps) => {
-  const { query } = ownProps
-
   return {
     updateStockInformations: (stockId, body, handleSuccess, handleFail) => {
+      const { query } = ownProps
       const context = query.context({ id: stockId, key: 'stock' })
       const { method } = context
       dispatch(
@@ -92,6 +91,16 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
           handleSuccess: handleSuccess,
           handleFail: handleFail,
           method,
+        })
+      )
+    },
+
+    deleteStock: (stockId, handleFail) => {
+      dispatch(
+        requestData({
+          apiPath: `stocks/${stockId}`,
+          handleFail: handleFail,
+          method: 'DELETE',
         })
       )
     },

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -9,6 +9,7 @@ import { translateQueryParamsToApiParams } from '../../../../../utils/translate'
 import { selectVenueById } from '../../../../../selectors/data/venuesSelectors'
 import { selectOffererById } from '../../../../../selectors/data/offerersSelectors'
 import { selectOfferById } from '../../../../../selectors/data/offersSelectors'
+import { requestData } from 'redux-saga-data'
 
 const getTimezoneFromDepartementCode = departementCode => {
   switch (departementCode) {
@@ -74,7 +75,30 @@ export const mapStateToProps = (state, ownProps) => {
   }
 }
 
+export const mapDispatchToProps = (dispatch, ownProps) => {
+  const { query } = ownProps
+
+  return {
+    updateStockInformations: (stockId, body, handleSuccess, handleFail) => {
+      const context = query.context({ id: stockId, key: 'stock' })
+      const { method } = context
+      dispatch(
+        requestData({
+          apiPath: `/stocks/${stockId || ''}`,
+          body,
+          handleSuccess: handleSuccess(Promise.resolve()),
+          handleFail: handleFail(Promise.resolve()),
+          method,
+        })
+      )
+    },
+  }
+}
+
 export default compose(
   withFrenchQueryRouter,
-  connect(mapStateToProps)
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )
 )(StockItem)

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -10,7 +10,7 @@ import { selectVenueById } from '../../../../../selectors/data/venuesSelectors'
 import { selectOffererById } from '../../../../../selectors/data/offerersSelectors'
 import { selectOfferById } from '../../../../../selectors/data/offersSelectors'
 import { requestData } from 'redux-saga-data'
-import OfferObject from '../../OfferObject'
+import Offer from '../../ValueObjects/Offer'
 
 const getTimezoneFromDepartementCode = departementCode => {
   switch (departementCode) {
@@ -65,7 +65,7 @@ export const mapStateToProps = (state, ownProps) => {
     timezone
   )
 
-  const offer = new OfferObject(associatedOffer)
+  const offer = new Offer(associatedOffer)
 
   return {
     hasIban,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -10,6 +10,7 @@ import { selectVenueById } from '../../../../../selectors/data/venuesSelectors'
 import { selectOffererById } from '../../../../../selectors/data/offerersSelectors'
 import { selectOfferById } from '../../../../../selectors/data/offersSelectors'
 import { requestData } from 'redux-saga-data'
+import OfferObject from '../../OfferObject'
 
 const getTimezoneFromDepartementCode = departementCode => {
   switch (departementCode) {
@@ -44,8 +45,8 @@ export const mapStateToProps = (state, ownProps) => {
   const { stockIdOrNew } = translateQueryParamsToApiParams(query.parse())
 
   const offerId = params.offerId
-  const offer = selectOfferById(state, offerId)
-  const { venueId } = offer || {}
+  const associatedOffer = selectOfferById(state, offerId)
+  const { venueId } = associatedOffer || {}
 
   const venue = selectVenueById(state, venueId)
   const managingOffererId = venue && venue.managingOffererId
@@ -63,6 +64,8 @@ export const mapStateToProps = (state, ownProps) => {
     managingOffererId,
     timezone
   )
+
+  const offer = new OfferObject(associatedOffer)
 
   return {
     hasIban,

--- a/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
+++ b/src/components/pages/Offer/StocksManager/StockItem/StockItemContainer.js
@@ -86,8 +86,8 @@ export const mapDispatchToProps = (dispatch, ownProps) => {
         requestData({
           apiPath: `/stocks/${stockId || ''}`,
           body,
-          handleSuccess: handleSuccess(Promise.resolve()),
-          handleFail: handleFail(Promise.resolve()),
+          handleSuccess: handleSuccess,
+          handleFail: handleFail,
           method,
         })
       )

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -10,6 +10,7 @@ import { createBrowserHistory } from 'history'
 import { Provider } from 'react-redux'
 import { Route, Router, Switch } from 'react-router-dom'
 import { Field } from 'react-final-form'
+import OfferObject from '../../../OfferObject'
 
 describe('src | components | pages | Offer | StocksManager | StockItem', () => {
   let props
@@ -22,12 +23,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       hasIban: false,
       history: { push: jest.fn() },
       isEvent: true,
-      offer: {
-        id: 'TY',
-        lastProvider: {
-          name: '',
-        },
-      },
+      offer: new OfferObject(),
       query: {
         changeToReadOnly: jest.fn(),
         context: () => ({ method: 'POST' }),
@@ -52,7 +48,6 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
     describe('when offer is an event', () => {
       beforeEach(() => {
         props.isEvent = true
-        props.offer.lastProvider = null
       })
 
       it('should render event fields', () => {
@@ -75,9 +70,9 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
         expect(eventFields).toHaveLength(1)
       })
 
-      describe('when the stocks are attached to an gffer provided from Allociné', () => {
+      describe('when the stocks are attached to an offer provided from Allociné', () => {
         beforeEach(() => {
-          props.offer.lastProvider = { name: 'Allociné' }
+          props.offer = new OfferObject({ lastProvider: { name: 'Allociné' } })
           props.query = { context: () => ({ readOnly: false }) }
         })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -87,6 +87,23 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
           expect(eventFields.props().readOnly).toBe(true)
         })
       })
+
+      describe('when the stocks are attached to an event offer', () => {
+        beforeEach(() => {
+          props.offer = new OfferObject({ id: 'AE', lastProvider: null })
+          props.query = { context: () => ({ readOnly: false }) }
+        })
+
+        it('event fields should be alterable', () => {
+          // When
+          const stockItemWrapper = shallow(<StockItem {...props} />)
+          const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))
+
+          // Then
+          const eventFields = formWrapper.find(EventFields)
+          expect(eventFields.props().readOnly).toBe(false)
+        })
+      })
     })
 
     describe('with event', () => {

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -33,6 +33,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
         id: 'DG',
       },
       stocks: [],
+      updateStockInformations: jest.fn(),
     }
   })
 
@@ -409,7 +410,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       expect(props.handleSetErrors).toHaveBeenCalledWith()
     })
 
-    it('should dispatch request data', () => {
+    it('should call updateStockInformations', () => {
       // given
       const wrapper = shallow(<StockItem {...props} />)
       const formValues = {
@@ -423,25 +424,20 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       wrapper.instance().handleOnFormSubmit(formValues)
 
       // then
-      const result = {
-        config: {
-          apiPath: '/stocks/DG',
-          body: {
-            available: null,
-            price: 0,
-            bookingLimitDatetime: '2019-03-13T22:00:00Z',
-            beginningDatetime: '2019-03-13T22:00:00Z',
-          },
-          handleFail: expect.any(Function),
-          handleSuccess: expect.any(Function),
-          method: 'POST',
+      expect(props.updateStockInformations).toHaveBeenCalledWith(
+        'DG',
+        {
+          available: null,
+          price: 0,
+          bookingLimitDatetime: '2019-03-13T22:00:00Z',
+          beginningDatetime: '2019-03-13T22:00:00Z',
         },
-        type: 'REQUEST_DATA_POST_/STOCKS/DG',
-      }
-      expect(props.dispatch).toHaveBeenCalledWith(result)
+        expect.any(Function),
+        expect.any(Function)
+      )
     })
 
-    it('should dispatch request data when offer is Event and booking limit date time is not provided', () => {
+    it('should call updateStockInformations when offer is Event and booking limit date time is not provided', () => {
       // given
       const wrapper = shallow(<StockItem {...props} />)
       const formValues = {
@@ -453,20 +449,14 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       wrapper.instance().handleOnFormSubmit(formValues)
 
       // then
-      const result = {
-        config: {
-          apiPath: '/stocks/DG',
-          body: {
-            bookingLimitDatetime: '2019-03-13T23:00:00Z',
-            beginningDatetime: '2019-03-13T23:00:00Z',
+
+      expect(props.updateStockInformations).toHaveBeenCalledWith('DG',
+          {
+            bookingLimitDatetime: '2019-03-13T22:00:00Z',
+            beginningDatetime: '2019-03-13T22:00:00Z',
           },
-          handleFail: expect.any(Function),
-          handleSuccess: expect.any(Function),
-          method: 'POST',
-        },
-        type: 'REQUEST_DATA_POST_/STOCKS/DG',
-      }
-      expect(props.dispatch).toHaveBeenCalledWith(result)
+          expect.any(Function),
+          expect.any(Function))
     })
   })
 
@@ -476,7 +466,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       const wrapper = shallow(<StockItem {...props} />)
 
       // when
-      wrapper.instance().handleRequestSuccess(jest.fn())()
+      wrapper.instance().handleRequestSuccess(jest.fn())
 
       // then
       expect(props.query.changeToReadOnly).toHaveBeenCalledWith(null, {

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -77,7 +77,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
           props.query = { context: () => ({ readOnly: false }) }
         })
 
-        it('event fields should not be alterable', () => {
+        it('beginning time and end time should not be alterable', () => {
           // When
           const stockItemWrapper = shallow(<StockItem {...props} />)
           const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))
@@ -94,7 +94,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
           props.query = { context: () => ({ readOnly: false }) }
         })
 
-        it('event fields should be alterable', () => {
+        it('beginning time and end time should be alterable', () => {
           // When
           const stockItemWrapper = shallow(<StockItem {...props} />)
           const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -468,13 +468,15 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
 
       // then
 
-      expect(props.updateStockInformations).toHaveBeenCalledWith('DG',
-          {
-            bookingLimitDatetime: '2019-03-13T22:00:00Z',
-            beginningDatetime: '2019-03-13T22:00:00Z',
-          },
-          expect.any(Function),
-          expect.any(Function))
+      expect(props.updateStockInformations).toHaveBeenCalledWith(
+        'DG',
+        {
+          bookingLimitDatetime: '2019-03-13T23:00:00Z',
+          beginningDatetime: '2019-03-13T23:00:00Z',
+        },
+        expect.any(Function),
+        expect.any(Function)
+      )
     })
   })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -24,6 +24,9 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       isEvent: true,
       offer: {
         id: 'TY',
+        lastProvider: {
+          name: '',
+        },
       },
       query: {
         changeToReadOnly: jest.fn(),
@@ -46,6 +49,50 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
   })
 
   describe('renderForm', () => {
+    describe('when offer is an event', () => {
+      beforeEach(() => {
+        props.isEvent = true
+        props.offer.lastProvider = null
+      })
+
+      it('should render event fields', () => {
+        // When
+        const stockItemWrapper = shallow(<StockItem {...props} />)
+        const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))
+
+        // Then
+        const eventFields = formWrapper.find(EventFields)
+        expect(eventFields).toHaveLength(1)
+      })
+
+      it('should render product fields', () => {
+        // When
+        const stockItemWrapper = shallow(<StockItem {...props} />)
+        const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))
+
+        // Then
+        const eventFields = formWrapper.find(ProductFieldsContainer)
+        expect(eventFields).toHaveLength(1)
+      })
+
+      describe('when the stocks are attached to an gffer provided from Allociné', () => {
+        beforeEach(() => {
+          props.offer.lastProvider = { name: 'Allociné' }
+          props.query = { context: () => ({ readOnly: false }) }
+        })
+
+        it('event fields should not be alterable', () => {
+          // When
+          const stockItemWrapper = shallow(<StockItem {...props} />)
+          const formWrapper = shallow(stockItemWrapper.instance().renderForm({ values: {} }))
+
+          // Then
+          const eventFields = formWrapper.find(EventFields)
+          expect(eventFields.props().readOnly).toBe(true)
+        })
+      })
+    })
+
     describe('with event', () => {
       let eventFieldComponent
       let productFieldsContainerComponent

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -89,7 +89,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
         })
       })
 
-      describe('when the stocks are attached to an event offer', () => {
+      describe('when the stocks are attached to an event offer created by the user', () => {
         beforeEach(() => {
           props.offer = new Offer({ id: 'AE', lastProvider: null })
           props.query = { context: () => ({ readOnly: false }) }

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItem.spec.jsx
@@ -10,7 +10,7 @@ import { createBrowserHistory } from 'history'
 import { Provider } from 'react-redux'
 import { Route, Router, Switch } from 'react-router-dom'
 import { Field } from 'react-final-form'
-import OfferObject from '../../../OfferObject'
+import Offer from '../../../ValueObjects/Offer'
 
 describe('src | components | pages | Offer | StocksManager | StockItem', () => {
   let props
@@ -23,7 +23,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       hasIban: false,
       history: { push: jest.fn() },
       isEvent: true,
-      offer: new OfferObject(),
+      offer: new Offer(),
       query: {
         changeToReadOnly: jest.fn(),
         context: () => ({ method: 'POST' }),
@@ -34,6 +34,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
       },
       stocks: [],
       updateStockInformations: jest.fn(),
+      deleteStock: jest.fn(),
     }
   })
 
@@ -73,7 +74,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
 
       describe('when the stocks are attached to an offer provided from Allociné', () => {
         beforeEach(() => {
-          props.offer = new OfferObject({ lastProvider: { name: 'Allociné' } })
+          props.offer = new Offer({ lastProvider: { name: 'Allociné' } })
           props.query = { context: () => ({ readOnly: false }) }
         })
 
@@ -90,7 +91,7 @@ describe('src | components | pages | Offer | StocksManager | StockItem', () => {
 
       describe('when the stocks are attached to an event offer', () => {
         beforeEach(() => {
-          props.offer = new OfferObject({ id: 'AE', lastProvider: null })
+          props.offer = new Offer({ id: 'AE', lastProvider: null })
           props.query = { context: () => ({ readOnly: false }) }
         })
 

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
@@ -1,5 +1,6 @@
 import { mapStateToProps, mapDispatchToProps } from '../StockItemContainer'
 import state from '../../../../../utils/mocks/state'
+import OfferObject from '../../../OfferObject'
 
 describe('stockItemContainer', () => {
   describe('mapStateToProps', () => {
@@ -20,6 +21,23 @@ describe('stockItemContainer', () => {
 
         // when
         const result = mapStateToProps(state, ownProps)
+        const expectedOffer = new OfferObject({
+          bookingEmail: 'booking.email@test.com',
+          dateCreated: '2019-03-07T10:39:23.560392Z',
+          dateModifiedAtLastProvider: '2019-03-07T10:40:05.443621Z',
+          isEvent: false,
+          isThing: true,
+          id: 'UU',
+          idAtProviders: null,
+          isActive: true,
+          lastProvider: null,
+          lastProviderId: null,
+          mediationsIds: ['H4'],
+          modelName: 'Offer',
+          productId: 'LY',
+          stocksIds: ['MU'],
+          venueId: 'DA',
+        })
         const expected = {
           event: undefined,
           formBeginningDatetime: undefined,
@@ -28,22 +46,7 @@ describe('stockItemContainer', () => {
           formPrice: undefined,
           hasIban: 'FR7630001007941234567890185',
           isStockReadOnly: true,
-          offer: {
-            bookingEmail: 'booking.email@test.com',
-            dateCreated: '2019-03-07T10:39:23.560392Z',
-            dateModifiedAtLastProvider: '2019-03-07T10:40:05.443621Z',
-            isEvent: false,
-            isThing: true,
-            id: 'UU',
-            idAtProviders: null,
-            isActive: true,
-            lastProviderId: null,
-            mediationsIds: ['H4'],
-            modelName: 'Offer',
-            productId: 'LY',
-            stocksIds: ['MU'],
-            venueId: 'DA',
-          },
+          offer: expectedOffer,
           stockFormKey: null,
           stockIdOrNew: undefined,
           formInitialValues: {

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
@@ -1,6 +1,6 @@
 import { mapStateToProps, mapDispatchToProps } from '../StockItemContainer'
 import state from '../../../../../utils/mocks/state'
-import OfferObject from '../../../OfferObject'
+import Offer from '../../../ValueObjects/Offer'
 
 describe('stockItemContainer', () => {
   describe('mapStateToProps', () => {
@@ -21,7 +21,7 @@ describe('stockItemContainer', () => {
 
         // when
         const result = mapStateToProps(state, ownProps)
-        const expectedOffer = new OfferObject({
+        const expectedOffer = new Offer({
           bookingEmail: 'booking.email@test.com',
           dateCreated: '2019-03-07T10:39:23.560392Z',
           dateModifiedAtLastProvider: '2019-03-07T10:40:05.443621Z',

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
@@ -7,6 +7,7 @@ import configureStore from 'redux-mock-store'
 
 import StockItemContainer, { mapStateToProps } from '../StockItemContainer'
 import state from '../../../../../utils/mocks/state'
+import { mapDispatchToProps } from '../StockItemContainer'
 
 describe('mount', () => {
   it('should reset the form when click on cancel button', () => {
@@ -146,6 +147,53 @@ describe('mount', () => {
 
         // then
         expect(result.offer).toStrictEqual(expected.offer)
+      })
+    })
+  })
+
+  describe('mapDispatchToProps', () => {
+    let dispatch
+
+    beforeEach(() => {
+      dispatch = jest.fn()
+    })
+
+    it('should submit stock item modification', () => {
+      // given
+      const handleSuccess = jest.fn()
+      const handleFail = jest.fn()
+      const ownProps = {
+        query: {
+          context: jest.fn().mockReturnValue({
+            method: '',
+          }),
+        },
+        stockPatch: {
+          id: '',
+          stockId: '',
+        },
+      }
+      const body = ''
+      const stockId = 'stockId'
+
+      // when
+      mapDispatchToProps(dispatch, ownProps).updateStockInformations(
+        stockId,
+        body,
+        handleSuccess,
+        handleFail
+      )
+
+      // then
+      expect(dispatch).toHaveBeenCalledWith({
+        config: {
+          apiPath: '/stocks/stockId',
+          body: '',
+          handleSuccess,
+          handleFail,
+          method: '',
+        },
+        type: 'REQUEST_DATA__/STOCKS/STOCKID',
       })
     })
   })

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
@@ -104,46 +104,69 @@ describe('stockItemContainer', () => {
       dispatch = jest.fn()
     })
 
-    it('should submit stock item modification', () => {
-      // given
-      const handleSuccess = jest.fn()
-      const handleFail = jest.fn()
-      const ownProps = {
-        query: {
-          context: jest.fn().mockReturnValue({
-            method: 'PATCH',
-          }),
-        },
-        stockPatch: {
-          id: 'stockId',
-          stockId: 'stockId',
-        },
-      }
-      const body = {
-        updatedField: 'updatedValue',
-      }
-      const stockId = 'stockId'
-
-      // when
-      mapDispatchToProps(dispatch, ownProps).updateStockInformations(
-        stockId,
-        body,
-        handleSuccess,
-        handleFail
-      )
-
-      // then
-      expect(dispatch).toHaveBeenCalledWith({
-        config: {
-          apiPath: '/stocks/stockId',
-          body: {
-            updatedField: 'updatedValue',
+    describe('updateStockInformations', () => {
+      it('should submit stock item modification', () => {
+        // given
+        const handleSuccess = jest.fn()
+        const handleFail = jest.fn()
+        const ownProps = {
+          query: {
+            context: jest.fn().mockReturnValue({
+              method: 'PATCH',
+            }),
           },
-          handleSuccess: handleSuccess,
-          handleFail: handleFail,
-          method: 'PATCH',
-        },
-        type: 'REQUEST_DATA_PATCH_/STOCKS/STOCKID',
+          stockPatch: {
+            id: 'stockId',
+            stockId: 'stockId',
+          },
+        }
+        const body = {
+          updatedField: 'updatedValue',
+        }
+        const stockId = 'stockId'
+
+        // when
+        mapDispatchToProps(dispatch, ownProps).updateStockInformations(
+          stockId,
+          body,
+          handleSuccess,
+          handleFail
+        )
+
+        // then
+        expect(dispatch).toHaveBeenCalledWith({
+          config: {
+            apiPath: '/stocks/stockId',
+            body: {
+              updatedField: 'updatedValue',
+            },
+            handleSuccess: handleSuccess,
+            handleFail: handleFail,
+            method: 'PATCH',
+          },
+          type: 'REQUEST_DATA_PATCH_/STOCKS/STOCKID',
+        })
+      })
+    })
+
+    describe('deleteStock', () => {
+      it('should submit stock deletion', () => {
+        // given
+        const handleFail = jest.fn()
+        const stockId = 'stockId'
+
+        // when
+        mapDispatchToProps(dispatch).deleteStock(stockId, handleFail)
+
+        // then
+        expect(dispatch).toHaveBeenCalledWith({
+          config: {
+            apiPath: 'stocks/stockId',
+            handleFail: handleFail,
+            method: 'DELETE',
+          },
+          type: 'REQUEST_DATA_DELETE_STOCKS/STOCKID',
+        })
       })
     })
   })

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/StockItemContainer.spec.jsx
@@ -1,64 +1,7 @@
-import { mount } from 'enzyme'
-import { createBrowserHistory } from 'history'
-import React from 'react'
-import { Provider } from 'react-redux'
-import { Route, Router, Switch } from 'react-router-dom'
-import configureStore from 'redux-mock-store'
-
-import StockItemContainer, { mapStateToProps } from '../StockItemContainer'
+import { mapStateToProps, mapDispatchToProps } from '../StockItemContainer'
 import state from '../../../../../utils/mocks/state'
-import { mapDispatchToProps } from '../StockItemContainer'
 
-describe('mount', () => {
-  it('should reset the form when click on cancel button', () => {
-    // given
-    const history = createBrowserHistory()
-    history.push(`/offres/AE?gestion&stockAE=modification`)
-    const middleWares = []
-    const mockStore = configureStore(middleWares)
-    const stock = { offerId: 'AE', id: 'AE' }
-    const store = mockStore({
-      data: {
-        offers: [{ id: 'AE', venueId: 'AE' }],
-        offerers: [{ id: 'AE' }],
-        products: [{ id: 'AE' }],
-        stocks: [stock],
-        venues: [{ id: 'AE', managingOffererId: 'AE' }],
-      },
-    })
-
-    const props = {
-      closeInfo: jest.fn(),
-      isEvent: true,
-      showInfo: jest.fn(),
-      stock,
-    }
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <Router history={history}>
-          <Switch>
-            <Route path="/offres/:offerId">
-              <StockItemContainer {...props} />
-            </Route>
-          </Switch>
-        </Router>
-      </Provider>
-    )
-
-    // when
-    wrapper.find("input[name='beginningTime']").simulate('change', { target: { value: '12:13' } })
-
-    expect(wrapper.find("input[name='beginningTime']").props().value).toStrictEqual('12:13')
-
-    // when
-    const cancelButton = wrapper.find('button[type="reset"]')
-    cancelButton.simulate('click')
-
-    // then
-    expect(wrapper.find("input[name='beginningTime']").props().value).toStrictEqual('')
-  })
-
+describe('stockItemContainer', () => {
   describe('mapStateToProps', () => {
     describe('when adding stock to one offer', () => {
       it('should map correctly the state', () => {
@@ -165,15 +108,17 @@ describe('mount', () => {
       const ownProps = {
         query: {
           context: jest.fn().mockReturnValue({
-            method: '',
+            method: 'PATCH',
           }),
         },
         stockPatch: {
-          id: '',
-          stockId: '',
+          id: 'stockId',
+          stockId: 'stockId',
         },
       }
-      const body = ''
+      const body = {
+        updatedField: 'updatedValue',
+      }
       const stockId = 'stockId'
 
       // when
@@ -188,12 +133,14 @@ describe('mount', () => {
       expect(dispatch).toHaveBeenCalledWith({
         config: {
           apiPath: '/stocks/stockId',
-          body: '',
-          handleSuccess,
-          handleFail,
-          method: '',
+          body: {
+            updatedField: 'updatedValue',
+          },
+          handleSuccess: handleSuccess,
+          handleFail: handleFail,
+          method: 'PATCH',
         },
-        type: 'REQUEST_DATA__/STOCKS/STOCKID',
+        type: 'REQUEST_DATA_PATCH_/STOCKS/STOCKID',
       })
     })
   })

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
@@ -16,8 +16,21 @@ ShallowWrapper {
     isEvent={true}
     offer={
       OfferObject {
+        "bookingEmail": undefined,
+        "dateCreated": undefined,
+        "dateModifiedAtLastProvider": undefined,
         "id": undefined,
+        "idAtProviders": undefined,
+        "isActive": undefined,
+        "isEvent": undefined,
+        "isThing": undefined,
         "lastProvider": null,
+        "lastProviderId": undefined,
+        "mediationsIds": undefined,
+        "modelName": undefined,
+        "productId": undefined,
+        "stocksIds": undefined,
+        "venueId": undefined,
       }
     }
     query={

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
@@ -5,6 +5,7 @@ ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
   Symbol(enzyme.__unrendered__): <StockItem
     closeInfo={[MockFunction]}
+    deleteStock={[MockFunction]}
     dispatch={[MockFunction]}
     handleSetErrors={[MockFunction]}
     hasIban={false}
@@ -15,7 +16,7 @@ ShallowWrapper {
     }
     isEvent={true}
     offer={
-      OfferObject {
+      Offer {
         "bookingEmail": undefined,
         "dateCreated": undefined,
         "dateModifiedAtLastProvider": undefined,

--- a/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/__specs__/__snapshots__/StockItem.spec.jsx.snap
@@ -15,8 +15,9 @@ ShallowWrapper {
     }
     isEvent={true}
     offer={
-      Object {
-        "id": "TY",
+      OfferObject {
+        "id": undefined,
+        "lastProvider": null,
       }
     }
     query={
@@ -33,6 +34,7 @@ ShallowWrapper {
     }
     stocks={Array []}
     timezone={null}
+    updateStockInformations={[MockFunction]}
     venue={Object {}}
   />,
   Symbol(enzyme.__renderer__): Object {

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/EditAndDeleteControl.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/EditAndDeleteControl.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types'
 import React, { PureComponent, Fragment } from 'react'
 import { Portal } from 'react-portal'
-import { requestData } from 'redux-saga-data'
 
 import DeleteDialog from '../DeleteDialog/DeleteDialog'
 import withFrenchQueryRouter from '../../../../../../hocs/withFrenchQueryRouter'
@@ -44,16 +43,10 @@ class EditAndDeleteControl extends PureComponent {
     query.changeToModification(null, { id: stockId, key: 'stock' })
 
   handleOnConfirmDeleteClick = () => {
-    const { dispatch, formInitialValues } = this.props
+    const { deleteStock, formInitialValues } = this.props
 
     const formSubmitPromise = new Promise(resolve => {
-      dispatch(
-        requestData({
-          apiPath: `stocks/${formInitialValues.id}`,
-          handleFail: this.handleRequestFail(resolve),
-          method: 'DELETE',
-        })
-      )
+      deleteStock(formInitialValues.id, this.handleRequestFail(resolve))
     })
     return formSubmitPromise
   }
@@ -116,7 +109,7 @@ class EditAndDeleteControl extends PureComponent {
 }
 
 EditAndDeleteControl.propTypes = {
-  dispatch: PropTypes.func.isRequired,
+  deleteStock: PropTypes.func.isRequired,
   formInitialValues: PropTypes.shape().isRequired,
   handleSetErrors: PropTypes.func.isRequired,
   isEvent: PropTypes.bool.isRequired,

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/EditAndDeleteControl.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/EditAndDeleteControl.spec.jsx
@@ -18,7 +18,7 @@ describe('src | components | pages | Offer | StockManager | StockItem | sub-comp
 
   beforeEach(() => {
     props = {
-      dispatch: jest.fn(),
+      deleteStock: jest.fn(),
       handleSetErrors: jest.fn(),
       formInitialValues: {
         id: 'EA',
@@ -60,10 +60,10 @@ describe('src | components | pages | Offer | StockManager | StockItem | sub-comp
       wrapper.instance().handleOnConfirmDeleteClick()
 
       // then
-      const requestDataArguments = requestData.mock.calls[0][0]
-      expect(requestDataArguments.apiPath).toBe(`stocks/${props.formInitialValues.id}`)
-      expect(requestDataArguments.method).toBe('DELETE')
-      expect(props.dispatch).toHaveBeenCalledWith(expectedAction)
+      expect(props.deleteStock).toHaveBeenCalledWith(
+        props.formInitialValues.id,
+        expect.any(Function)
+      )
     })
   })
 })

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/__snapshots__/EditAndDeleteControl.spec.jsx.snap
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/EditAndDeleteControl/__specs__/__snapshots__/EditAndDeleteControl.spec.jsx.snap
@@ -16,7 +16,7 @@ ShallowWrapper {
     }
   >
     <withRouter(_withQueryRouter)
-      dispatch={[MockFunction]}
+      deleteStock={[MockFunction]}
       formInitialValues={
         Object {
           "id": "EA",
@@ -46,7 +46,7 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
-      "dispatch": [MockFunction],
+      "deleteStock": [MockFunction],
       "formInitialValues": Object {
         "id": "EA",
       },
@@ -67,7 +67,7 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
-        "dispatch": [MockFunction],
+        "deleteStock": [MockFunction],
         "formInitialValues": Object {
           "id": "EA",
         },

--- a/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/EventFields.spec.jsx
+++ b/src/components/pages/Offer/StocksManager/StockItem/sub-components/fields/EventFields/__specs__/EventFields.spec.jsx
@@ -2,6 +2,8 @@ import { shallow } from 'enzyme'
 import React from 'react'
 
 import EventFields from '../EventFields'
+import DateField from '../../../../../../../../layout/form/fields/DateField'
+import TimeField from '../../../../../../../../layout/form/fields/TimeField'
 
 describe('src | components | pages | Offer | StockItem | EventFields', () => {
   it('should match the snapshot', () => {
@@ -17,5 +19,36 @@ describe('src | components | pages | Offer | StockItem | EventFields', () => {
 
     // then
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('should display a DateField to inform about begginning DateTime', () => {
+    // when
+    const wrapper = shallow(<EventFields />)
+
+    // then
+    const dateField = wrapper.find(DateField)
+    expect(dateField).toHaveLength(1)
+  })
+
+  it('should display a TimeField to inform about begginning time hour', () => {
+    // when
+    const wrapper = shallow(<EventFields />)
+
+    // then
+    const timeField = wrapper.find(TimeField).findWhere(timeFieldComponent => {
+      return timeFieldComponent.props().name === 'beginningTime'
+    })
+    expect(timeField).toHaveLength(1)
+  })
+
+  it('should display a TimeField to inform about end time hour', () => {
+    // when
+    const wrapper = shallow(<EventFields />)
+
+    // then
+    const timeField = wrapper.find(TimeField).findWhere(timeFieldComponent => {
+      return timeFieldComponent.props().name === 'endTime'
+    })
+    expect(timeField).toHaveLength(1)
   })
 })

--- a/src/components/pages/Offer/ValueObjects/Offer.js
+++ b/src/components/pages/Offer/ValueObjects/Offer.js
@@ -1,4 +1,4 @@
-export default class OfferObject {
+export default class Offer {
   constructor(offer = {}) {
     this.bookingEmail = offer.bookingEmail
     this.dateCreated = offer.dateCreated

--- a/src/components/pages/Offer/__specs__/Offer.spec.jsx
+++ b/src/components/pages/Offer/__specs__/Offer.spec.jsx
@@ -541,18 +541,6 @@ describe('src | components | pages | Offer | Offer ', () => {
     })
 
     describe('when offer is not editable', () => {
-      it('should not be possible to manage stocks', () => {
-        // given
-        props.isEditableOffer = false
-
-        // when
-        const wrapper = shallow(<Offer {...props} />)
-
-        // then
-        const manageStockButton = wrapper.find('#manage-stocks')
-        expect(manageStockButton.prop('disabled')).toStrictEqual('disabled')
-      })
-
       it('should not be possible to modify offer', () => {
         // given
         props.query.context = () => ({
@@ -639,61 +627,109 @@ describe('src | components | pages | Offer | Offer ', () => {
         expect(modifyOfferButton.prop('disabled')).toStrictEqual('')
       })
     })
-  })
 
-  describe('event tracking', () => {
-    it('should track offer creation', () => {
-      // given
-      const state = {}
+    describe('stock management button', () => {
+      describe('when offer is from Titelive provider', () => {
+        it('should not be possible to change management stock button', () => {
+          // given
+          props.offer.lastProvider = {
+            name: 'Titelive',
+          }
 
-      const action = {
-        payload: {
-          datum: {
-            id: 'Ty5645dgfd',
-          },
-        },
-      }
-      jest.spyOn(props.query, 'context').mockReturnValue({
-        isCreatedEntity: true,
+          // when
+          const wrapper = shallow(<Offer {...props} />)
+
+          // then
+          const manageStockButton = wrapper.find('#manage-stocks')
+          expect(manageStockButton.prop('disabled')).toStrictEqual('disabled')
+        })
       })
-      const wrapper = shallow(<Offer {...props} />)
 
-      // when
-      wrapper.instance().onHandleFormSuccess(state, action)
+      describe('when offer is not from Allociné provider', () => {
+        it('should be possible to change management stock button', () => {
+          // given
+          props.offer.lastProvider = {
+            name: 'Allociné',
+          }
 
-      // then
-      expect(props.trackCreateOffer).toHaveBeenCalledWith('Ty5645dgfd')
+          // when
+          const wrapper = shallow(<Offer {...props} />)
+
+          // then
+          const manageStockButton = wrapper.find('#manage-stocks')
+          expect(manageStockButton.prop('disabled')).toStrictEqual('')
+        })
+      })
+
+      describe('when offer has been created manually', () => {
+        it('should be possible to change management stock button', () => {
+          // given
+          props.offer.lastProvider = null
+
+          // when
+          const wrapper = shallow(<Offer {...props} />)
+
+          // then
+          const manageStockButton = wrapper.find('#manage-stocks')
+          expect(manageStockButton.prop('disabled')).toStrictEqual('')
+        })
+      })
     })
 
-    it('should track offer update', () => {
-      // given
-      const state = {}
+    describe('event tracking', () => {
+      it('should track offer creation', () => {
+        // given
+        const state = {}
 
-      props.offer = {
-        id: 'RTgYD45',
-        lastProvider: null,
-      }
+        const action = {
+          payload: {
+            datum: {
+              id: 'Ty5645dgfd',
+            },
+          },
+        }
+        jest.spyOn(props.query, 'context').mockReturnValue({
+          isCreatedEntity: true,
+        })
+        const wrapper = shallow(<Offer {...props} />)
 
-      jest.spyOn(props.query, 'context').mockReturnValue({
-        isCreatedEntity: false,
-        isModifiedEntity: false,
-        readOnly: false,
+        // when
+        wrapper.instance().onHandleFormSuccess(state, action)
+
+        // then
+        expect(props.trackCreateOffer).toHaveBeenCalledWith('Ty5645dgfd')
       })
 
-      const action = {
-        payload: {
-          datum: {
-            id: 'Ty5645dgfd',
+      it('should track offer update', () => {
+        // given
+        const state = {}
+
+        props.offer = {
+          id: 'RTgYD45',
+          lastProvider: null,
+        }
+
+        jest.spyOn(props.query, 'context').mockReturnValue({
+          isCreatedEntity: false,
+          isModifiedEntity: false,
+          readOnly: false,
+        })
+
+        const action = {
+          payload: {
+            datum: {
+              id: 'Ty5645dgfd',
+            },
           },
-        },
-      }
-      const wrapper = shallow(<Offer {...props} />)
+        }
+        const wrapper = shallow(<Offer {...props} />)
 
-      // when
-      wrapper.instance().onHandleFormSuccess(state, action)
+        // when
+        wrapper.instance().onHandleFormSuccess(state, action)
 
-      // then
-      expect(props.trackModifyOffer).toHaveBeenCalledWith('RTgYD45')
+        // then
+        expect(props.trackModifyOffer).toHaveBeenCalledWith('RTgYD45')
+      })
     })
   })
 })

--- a/src/components/pages/Offer/__specs__/Offer.spec.jsx
+++ b/src/components/pages/Offer/__specs__/Offer.spec.jsx
@@ -645,7 +645,7 @@ describe('src | components | pages | Offer | Offer ', () => {
         })
       })
 
-      describe('when offer is not from Allociné provider', () => {
+      describe('when offer is from Allociné provider', () => {
         it('should be possible to change management stock button', () => {
           // given
           props.offer.lastProvider = {
@@ -705,7 +705,7 @@ describe('src | components | pages | Offer | Offer ', () => {
         const state = {}
 
         props.offer = {
-          id: 'RTgYD45',
+          id: 'A9',
           lastProvider: null,
         }
 
@@ -728,7 +728,7 @@ describe('src | components | pages | Offer | Offer ', () => {
         wrapper.instance().onHandleFormSuccess(state, action)
 
         // then
-        expect(props.trackModifyOffer).toHaveBeenCalledWith('RTgYD45')
+        expect(props.trackModifyOffer).toHaveBeenCalledWith('A9')
       })
     })
   })

--- a/src/components/pages/Offer/__specs__/Offer.spec.jsx
+++ b/src/components/pages/Offer/__specs__/Offer.spec.jsx
@@ -630,7 +630,7 @@ describe('src | components | pages | Offer | Offer ', () => {
 
     describe('stock management button', () => {
       describe('when offer is from Titelive provider', () => {
-        it('should not be possible to change management stock button', () => {
+        it('should not be possible to change stock values', () => {
           // given
           props.offer.lastProvider = {
             name: 'Titelive',
@@ -646,7 +646,7 @@ describe('src | components | pages | Offer | Offer ', () => {
       })
 
       describe('when offer is from Allociné provider', () => {
-        it('should be possible to change management stock button', () => {
+        it('should be possible to change stock values', () => {
           // given
           props.offer.lastProvider = {
             name: 'Allociné',
@@ -662,7 +662,7 @@ describe('src | components | pages | Offer | Offer ', () => {
       })
 
       describe('when offer has been created manually', () => {
-        it('should be possible to change management stock button', () => {
+        it('should be possible to change stock values', () => {
           // given
           props.offer.lastProvider = null
 


### PR DESCRIPTION
Cette PR permettra aux pro qui importent les offres depuis Allociné de gérer leurs stocks depuis l'interface PRO. Ils pourront modifier : le nombre de place disponibles, la date limite de réservation et le prix de leur place.

Cette PR va de pair avec : https://github.com/betagouv/pass-culture-api/pull/1019

Story JIRA : https://passculture.atlassian.net/secure/RapidBoard.jspa?rapidView=2&projectKey=PC&modal=detail&selectedIssue=PC-2882